### PR TITLE
[Draft] Call python3 with -S for faster startup 

### DIFF
--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -7,6 +7,7 @@ from parse import parse_shell, from_ir_to_shell, from_ir_to_shell_file
 from expand import *
 import subprocess
 import traceback
+import sys
 
 import config
 
@@ -184,7 +185,7 @@ def combine_pipe(ast_nodes):
     else:
         ## If any part of the pipe is not an IR, the compilation must fail.
         log("Node: {} is not pure".format(AstNode(ast_nodes[0])))
-        exit(1)
+        sys.exit(1)
 
     ## Combine the rest of the nodes
     for ast_node in ast_nodes[1:]:
@@ -193,7 +194,7 @@ def combine_pipe(ast_nodes):
         else:
             ## If any part of the pipe is not an IR, the compilation must fail.
             log("Node: {} is not pure".format(AstNode(ast_nodes)))
-            exit(1)
+            sys.exit(1)
 
     return [combined_nodes]
 

--- a/compiler/config.py
+++ b/compiler/config.py
@@ -15,8 +15,6 @@ if 'PASH_TOP' in os.environ:
 else:
     PASH_TOP = subprocess.run(GIT_TOP_CMD, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).stdout.rstrip()
 
-PYTHON_VERSION = "python3"
-PLANNER_EXECUTABLE = os.path.join(PASH_TOP, "compiler/pash_runtime.py")
 RUNTIME_EXECUTABLE = os.path.join(PASH_TOP, "compiler/pash_runtime.sh")
 
 ## This is set in pash.py and pash_runtime.py accordingly.

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -27,7 +27,7 @@ def from_ir_to_shell(ir_filename):
 def parse_shell(input_script_path):
     if(not os.path.isfile(input_script_path)):
         log("Error! File:", input_script_path, "does not exist.", level=0)
-        exit(1)
+        sys.exit(1)
     parser_output = subprocess.run([config.PARSER_BINARY, input_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     if (not parser_output.returncode == 0):
         log(parser_output.stderr)

--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -87,7 +87,7 @@ def parse_args():
 
     if (args.input == None):
         parser.print_usage()
-        exit()
+        sys.exit(0)
 
     ## Print all the arguments
     log("Arguments:")
@@ -119,7 +119,7 @@ def execute_script(compiled_script_filename, debug_level, command):
         os.remove(config.config['runtime']['immediate'])
     log("-" * 40) #log end marker
     ## Return the exit code of the executed script
-    exit(exec_obj.returncode)
+    sys.exit(exec_obj.returncode)
 
 if __name__ == "__main__":
     main()

--- a/compiler/pash_runtime.py
+++ b/compiler/pash_runtime.py
@@ -38,7 +38,7 @@ def main():
     except Exception:
         log("Compiler failed, no need to worry, executing original script...")
         log(traceback.format_exc())
-        exit(1)
+        sys.exit(1)
 
 def main_body():
     ## Parse arguments
@@ -133,7 +133,7 @@ def compile_optimize_script(ir_filename, compiled_script_file, args):
     else:
         ## Instead of outputing the script here, we just want to exit with a specific exit code
         ## TODO: Figure out the code and save it somewhere
-        exit(120)
+        sys.exit(120)
 
 
 def compile_candidate_df_region(candidate_df_region, config):

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -222,7 +222,7 @@ if [ "$pash_speculation_flag" -eq 1 ]; then
     source "$RUNTIME_DIR/pash_runtime_quick_abort.sh"
     pash_runtime_final_status=$?
 else
-    python3 "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
+    python3 -S "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
     pash_runtime_return_code=$?
     pash_redir_output echo "$$: Compiler exited with code: $pash_runtime_return_code"
     if [ "$pash_runtime_return_code" -ne 0 ] && [ "$pash_assert_compiler_success_flag" -eq 1 ]; then

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -152,7 +152,7 @@ if [ "$pash_execute_flag" -eq 1 ]; then
     par_eager_pid=$(spawn_eager "parallel input" "$pash_tee_stdout2" "$pash_par_eager_output")
 
     ## Run the compiler
-    setsid python3 "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}" &
+    setsid python3 -S "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}" &
     pash_compiler_pid=$!
     log "Compiler pid: $pash_compiler_pid"
 

--- a/pa.sh
+++ b/pa.sh
@@ -14,4 +14,4 @@ then
     exit
 fi
 
-PASH_FROM_SH="pa.sh" python3 $PASH_TOP/compiler/pash.py "$@"
+PASH_FROM_SH="pa.sh" python3 -S $PASH_TOP/compiler/pash.py "$@"


### PR DESCRIPTION
We can call python3 with the `-S` flag for faster startup times. 

TODO: For this to work, we have to make sure that the dependencies are installed in a local directory and that they are added in the `PYTHONPATH`.