### PR TITLE
Ignore paths for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
         - compiler/**
         - runtime/**
         - evaluation/**
+        - "!evaluation/benchmarks**"
+        - '!**.md'
         - annotations/**
 # Jobs section
 jobs:


### PR DESCRIPTION
We could/should add more paths/files that should not trigger the CI.
All *.md file changes (even from compiler,runtime,evaluation,annotations) are ignored.
Changes to the benchmarks folder do not trigger the tests.

Signed-off-by: DIMITRIS KARNIKIS <dkarnikis@gmail.com>