### PR TITLE
Fix space in wf's `tr`

### DIFF
--- a/evaluation/benchmarks/oneliners/wf.sh
+++ b/evaluation/benchmarks/oneliners/wf.sh
@@ -3,4 +3,4 @@
 
 IN=${IN:-$PASH_TOP/evaluation/benchmarks/oneliners/input/1G.txt}
 
-cat $IN | tr -cs A-Za-z'\n' | tr A-Z a-z | sort | uniq -c | sort -rn 
+cat $IN | tr -cs A-Za-z '\n' | tr A-Z a-z | sort | uniq -c | sort -rn 


### PR DESCRIPTION
Word frequencies seems to have a bug in its invocation of `tr -cs` (a missing space).