### PR TITLE
Include limits.h to comply with g++11 version [skip ci]

### DIFF
--- a/runtime/agg/cpp/aggregators/wc/agg-linux.h
+++ b/runtime/agg/cpp/aggregators/wc/agg-linux.h
@@ -1,6 +1,8 @@
 #ifndef AGG_WC_H
 #define AGG_WC_H
 
+#include <limits>
+
 #include "common.h"
 
 size_t platform_dependent(int&) {

--- a/runtime/agg/cpp/aggregators/wc/common.h
+++ b/runtime/agg/cpp/aggregators/wc/common.h
@@ -2,7 +2,6 @@
 #include <string>
 #include <algorithm>
 #include <cstdlib>
-#include <limits.h>
 
 inline constexpr cmd_opts g_options{
     cmd_opt{"lines",'l', cmd_opt::Argument::None},

--- a/runtime/agg/cpp/aggregators/wc/common.h
+++ b/runtime/agg/cpp/aggregators/wc/common.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <algorithm>
 #include <cstdlib>
+#include <limits.h>
 
 inline constexpr cmd_opts g_options{
     cmd_opt{"lines",'l', cmd_opt::Argument::None},


### PR DESCRIPTION
Since g++11, it is required to include `<limits.h>` in the code.
Signed-off-by: DIMITRIS KARNIKIS <dkarnikis@gmail.com>