### PR TITLE
Redirect the output of pash_runtime to the log

### DIFF
--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -225,7 +225,7 @@ if [ "$pash_speculation_flag" -eq 1 ]; then
     source "$RUNTIME_DIR/pash_runtime_quick_abort.sh"
     pash_runtime_final_status=$?
 else
-    python3 "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
+    pash_redir_all_output python3 "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
     pash_runtime_return_code=$?
     pash_redir_output echo "$$: Compiler exited with code: $pash_runtime_return_code"
     if [ "$pash_runtime_return_code" -ne 0 ] && [ "$pash_assert_compiler_success_flag" -eq 1 ]; then

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -91,6 +91,19 @@ test7()
     $shell args_with_spaces.sh "hello there" "hi friend"
 }
 
+test8()
+{
+    local shell=$1
+    $shell -c 'shift 5; echo $#' pash 2 3 4
+}
+
+test9()
+{
+    local shell=$1
+    $shell tilde.sh
+}
+
+
 ## We run all tests composed with && to exit on the first that fails
 if [ "$#" -eq 0 ]; then
     run_test test1 &&
@@ -98,8 +111,10 @@ if [ "$#" -eq 0 ]; then
     run_test test3 && # This is commented out at the moment because it doesn't suceed
     run_test test4 &&
     run_test test5 &&
-    run_test test6
+    run_test test6 &&
     # && run_test test7
+    run_test test8 &&
+    run_test test9
 else
     for testname in $@
     do

--- a/evaluation/tests/interface_tests/tilde.sh
+++ b/evaluation/tests/interface_tests/tilde.sh
@@ -1,0 +1,4 @@
+HOME='abc        xyz'
+printf '%s\n' ~
+HOME='test.*'
+printf '%s\n' ~


### PR DESCRIPTION
Redirect the output of `pash_runtime` to a log to ensure that it doesn't get mixed up (this is particularly important when changes in the environment lead to `import` failures).

Interface `test9` exhibits that behavior.