### PR TITLE
Fix broken link on tutorial

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -109,7 +109,7 @@ More information in the [pash-on-docker guide](../contrib#pash-on-docker-a-pocke
 #### Windows using WSL
 
 To run PaSh on windows without Docker, install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
-A short tutorial is included in the [contributing](../contrib/) guide.
+A short tutorial is included in the [contributing](../contributing/contrib.md) guide.
 
 ## Running Scripts
 


### PR DESCRIPTION
Fix broken link not pointing to the correct file for WSL installation as mentioned in https://github.com/binpash/pash/issues/327