### PR TITLE
Set-e does not apply when executing in the context of `&&` or `||`

### DIFF
--- a/compiler/definitions/ast_node.py
+++ b/compiler/definitions/ast_node.py
@@ -196,5 +196,9 @@ def ast_node_to_untyped_deep(node):
         return [json_key, untyped_json_val]
     elif(isinstance(node, list)):
         return [ast_node_to_untyped_deep(obj) for obj in node]
+    elif(isinstance(node, tuple)):
+        return [ast_node_to_untyped_deep(obj) for obj in node]
+    elif(isinstance(node, dict)):
+        return {k: ast_node_to_untyped_deep(v) for k, v in node.items()}
     else:
         return node

--- a/compiler/pash_set_from_to.sh
+++ b/compiler/pash_set_from_to.sh
@@ -4,8 +4,8 @@ from_set=${1?From set not given}
 to_set=${2?To set not given}
 
 ## Finds the difference of set variables (removing the c, s one since it cannot be actually set and unset)
-pash_set_to_add="$(comm -23 <(echo $to_set | sed -E 's/(.)/\1\n/g' | sort) <(echo $from_set | sed -E 's/(.)/\1\n/g' | sort) | grep -v 'c' | grep -v 's' )"
-pash_set_to_remove="$(comm -13 <(echo $to_set | sed -E 's/(.)/\1\n/g' | sort) <(echo $from_set | sed -E 's/(.)/\1\n/g' | sort) | grep -v 'c' | grep -v 's' )"
+pash_set_to_add="$(comm -23 <(echo $to_set | sed -E 's/(.)/\1\n/g' | sort) <(echo $from_set | sed -E 's/(.)/\1\n/g' | sort) | grep -v 'c' | grep -v 's' || true )"
+pash_set_to_remove="$(comm -13 <(echo $to_set | sed -E 's/(.)/\1\n/g' | sort) <(echo $from_set | sed -E 's/(.)/\1\n/g' | sort) | grep -v 'c' | grep -v 's' || true )"
 pash_redir_output echo "To add: $pash_set_to_add"
 pash_redir_output echo "To remove: $pash_set_to_remove"
 pash_redir_all_output set "-$pash_set_to_add"

--- a/compiler/pash_wrap_vars.sh
+++ b/compiler/pash_wrap_vars.sh
@@ -29,12 +29,22 @@ set -- $pash_input_args
 pash_redir_output echo "$$: (3) Reverted to BaSh input arguments: $@"
 
 ## Execute the script
-pash_redir_output echo "$$: (4) Executing script in ${script_source}:"
+pash_redir_output echo "$$: (4) Restoring previous exit code: ${pash_previous_exit_status}"
+pash_redir_output echo "$$: (4) Will execute script in ${script_source}:"
 pash_redir_output cat "${script_source}"
 ## Note: We run the `exit` in a checked position so that we don't simply exit when we are in `set -e`.
 if (exit "$pash_previous_exit_status")
-then source "${script_source}" && internal_exec_status=$? || internal_exec_status=$?
-else source "${script_source}" && internal_exec_status=$? || internal_exec_status=$?
+then 
+{
+    # source "${script_source}" && internal_exec_status=$? || internal_exec_status=$?
+    source "${script_source}"
+    internal_exec_status=$?
+}
+else 
+{
+    source "${script_source}"
+    internal_exec_status=$?
+}
 fi
 pash_exec_status=${internal_exec_status}
 pash_redir_output echo "$$: (5) BaSh script exited with ec: $pash_exec_status"

--- a/compiler/pash_wrap_vars.sh
+++ b/compiler/pash_wrap_vars.sh
@@ -36,6 +36,7 @@ pash_redir_output cat "${script_source}"
 if (exit "$pash_previous_exit_status")
 then 
 {
+    ## Old way of executing the script but it doesn't properly work because the position is unchecked and therefore `set -e` doesn't behave as expected.
     # source "${script_source}" && internal_exec_status=$? || internal_exec_status=$?
     source "${script_source}"
     internal_exec_status=$?

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -45,7 +45,7 @@ run_test()
         return 1
     else
         echo "are identical" > $output_dir/${test}_distr.time
-        echo '   OK'
+        echo '\t\tOK'
         return 0
     fi
 }
@@ -172,6 +172,12 @@ test_set_e()
     $shell set-e.sh
 }
 
+test_set_e_2()
+{
+    local shell=$1
+    $shell set-e-2.sh
+}
+
 test_redirect()
 {
     local shell=$1
@@ -207,6 +213,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_set_e
     run_test test_redirect
     run_test test_unparsing
+    run_test test_set_e_2
 else
     for testname in $@
     do

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -178,6 +178,12 @@ test_set_e_2()
     $shell set-e-2.sh
 }
 
+test_set_e_3()
+{
+    local shell=$1
+    $shell set-e-3.sh
+}
+
 test_redirect()
 {
     local shell=$1
@@ -214,6 +220,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_redirect
     run_test test_unparsing
     run_test test_set_e_2
+    run_test test_set_e_3
 else
     for testname in $@
     do

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -41,11 +41,11 @@ run_test()
     fi
     if [ $test_diff_ec -ne 0 ] || [ $test_ec -ne 0 ]; then
         echo "are not identical" > $output_dir/${test}_distr.time
-        echo '   FAIL'
+        echo -e '\t\tFAIL'
         return 1
     else
         echo "are identical" > $output_dir/${test}_distr.time
-        echo '\t\tOK'
+        echo -e '\t\tOK'
         return 0
     fi
 }

--- a/evaluation/tests/interface_tests/set-e-2.sh
+++ b/evaluation/tests/interface_tests/set-e-2.sh
@@ -1,0 +1,5 @@
+set -x
+set -e
+( { false; }
+  { echo one; } ) | cat
+echo two

--- a/evaluation/tests/interface_tests/set-e-2.sh
+++ b/evaluation/tests/interface_tests/set-e-2.sh
@@ -1,4 +1,3 @@
-set -x
 set -e
 ( { false; }
   { echo one; } ) | cat

--- a/evaluation/tests/interface_tests/set-e-3.sh
+++ b/evaluation/tests/interface_tests/set-e-3.sh
@@ -1,0 +1,21 @@
+set -e
+# individual command in a multi-command pipeline
+false | :
+echo passed pipeline
+# part of a compound list of an 'elif'
+if false; then :; elif false; then :; fi
+echo passed elif
+# non-subshell compound command whose exit status was the result
+# of a failure while -e was being ignored
+{ false && : ; }
+echo passed compound-brace
+for i in a; do false && : ; done
+echo passed compound-for
+# case x in x) false && : ;; esac
+# echo passed compound-case
+if :; then false && : ; fi
+echo passed compound-if
+cont=y; while [ $cont = y ]; do cont=n; false && : ; done
+echo passed compound-while
+end=n; until [ $end = y ]; do end=y; false && : ; done
+echo passed compound-until


### PR DESCRIPTION
PaSh currently sources parts of the script in the context of `&&` and `||` and based on the bash documentation, this prevents `set -e` from working (focus in bold):


> -e
>
>    Exit immediately if a pipeline (see Pipelines), which may consist of a single simple command (see Simple Commands), a list (see Lists), or a compound command (see Compound Commands) returns a non-zero status. The shell does not exit if the command that fails is part of the command list immediately following a while or until keyword, part of the test in an if statement, **part of any command executed in a && or || list** except the command following the final && or ||, any command in a pipeline but the last, or if the command’s return status is being inverted with !. If a compound command other than a subshell returns a non-zero status because a command failed while -e was being ignored, the shell does not exit. A trap on ERR, if set, is executed before the shell exits. 

It is not clear how to fix this since we cannot just `source` because this would lead to a premature exit without restoring state properly. Is that an actual issue though?
