### PR TITLE
Invoke PaSh with -S and install dependencies in local dir

### DIFF
--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -12,7 +12,7 @@ import traceback
 import config
 
 import pickle
-
+import sys
 
 ##
 ## Compile AST -> Extended AST with IRs
@@ -187,7 +187,7 @@ def combine_pipe(ast_nodes):
     else:
         ## If any part of the pipe is not an IR, the compilation must fail.
         log("Node: {} is not pure".format(ast_nodes[0]))
-        exit(1)
+        sys.exit(1)
 
     ## Combine the rest of the nodes
     for ast_node in ast_nodes[1:]:
@@ -196,7 +196,7 @@ def combine_pipe(ast_nodes):
         else:
             ## If any part of the pipe is not an IR, the compilation must fail.
             log("Node: {} is not pure".format(ast_nodes))
-            exit(1)
+            sys.exit(1)
 
     return [combined_nodes]
 

--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -12,6 +12,7 @@ import config
 import pprint
 import tempfile
 import shutil
+import sys
 
 def main():
     ## Parse arguments
@@ -39,7 +40,7 @@ def main():
             shutil.rmtree(config.PASH_TMP_PREFIX)
         log("-" * 40) #log end marker
         ## Return the exit code of the executed script
-        exit(return_code)
+        sys.exit(return_code)
 
 def preprocess_ast(ast_objects, args):
     ## 2. Preprocess ASTs by replacing possible candidates for compilation
@@ -134,7 +135,7 @@ def interactive(args, shell_name):
             shutil.rmtree(config.PASH_TMP_PREFIX)
         log("-" * 40) #log end marker
         ## Return the exit code of the executed script
-        exit(shell_proc.returncode)
+        sys.exit(shell_proc.returncode)
 
 
 def parse_args():

--- a/compiler/pash_runtime.py
+++ b/compiler/pash_runtime.py
@@ -35,7 +35,7 @@ def main():
     except Exception:
         log("Compiler failed, no need to worry, executing original script...")
         log(traceback.format_exc())
-        exit(1)
+        sys.exit(1)
 
 def main_body():
     ## Parse arguments
@@ -130,7 +130,7 @@ def compile_optimize_script(ir_filename, compiled_script_file, args):
     else:
         ## Instead of outputing the script here, we just want to exit with a specific exit code
         ## TODO: Figure out the code and save it somewhere
-        exit(120)
+        sys.exit(120)
 
 
 def compile_candidate_df_region(candidate_df_region, config):

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -222,13 +222,19 @@ if [ "$pash_speculation_flag" -eq 1 ]; then
     ## For now this will fail!!!
     exit 1
 else
-    pash_redir_all_output python3 "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
+    pash_compilation_time_start=$(date +"%s%N")
+    pash_redir_all_output python3 -S "$RUNTIME_DIR/pash_runtime.py" ${pash_compiled_script_file} --var_file "${pash_runtime_shell_variables_file}" "${@:2}"
     pash_runtime_return_code=$?
     pash_redir_output echo "$$: Compiler exited with code: $pash_runtime_return_code"
     if [ "$pash_runtime_return_code" -ne 0 ] && [ "$pash_assert_compiler_success_flag" -eq 1 ]; then
         pash_redir_output echo "$$: ERROR: Compiler failed with error code: $pash_runtime_return_code"
         exit 1
     fi
+    pash_compilation_time_end=$(date +"%s%N")
+
+    pash_compilation_time_ms=$(echo "scale = 3; ($pash_compilation_time_end-$pash_compilation_time_start)/1000000" | bc)
+    pash_redir_output echo "Compilation time: $pash_compilation_time_ms  ms"
+
 
     ##
     ## (3)

--- a/pa.sh
+++ b/pa.sh
@@ -14,4 +14,4 @@ then
     exit
 fi
 
-PASH_FROM_SH="pa.sh" python3 $PASH_TOP/compiler/pash.py "$@"
+PASH_FROM_SH="pa.sh" python3 -S $PASH_TOP/compiler/pash.py "$@"


### PR DESCRIPTION
Invoking `pash_runtime.py` through python is pretty slow on some environments.

The solution would be to either invoke python3 with the `-S` flag (which does not load a lot of unneccessary stuff) and/or properly installing PaSh as a python application together with its dependencies.