### PR TITLE
Remove arch installation

### DIFF
--- a/scripts/distro-deps.sh
+++ b/scripts/distro-deps.sh
@@ -46,11 +46,11 @@ case "$distro" in
      echo "|-- running dnf install...."
      dnf install git gcc gcc-c++ python3-pip make curl automake autoconf libtool hostname bc procps -y &> $LOG_DIR/dnf_install.log
      ;;
-   arch*) 
-     echo "Updating mirrors"
-     pacman -Sy &> $LOG_DIR/pacman_update.log
-     echo "|-- running pacman install...."
-     yes | pacman -S git libtool m4 automake curl pkg-config python-pip libffi make autoconf gcc10 sudo inetutils bc
-     ;;
+   #arch*) 
+     #echo "Updating mirrors"
+     #pacman -Sy &> $LOG_DIR/pacman_update.log
+     #echo "|-- running pacman install...."
+     #yes | pacman -S git libtool m4 automake curl pkg-config python-pip libffi make autoconf gcc10 sudo inetutils bc
+     #;;
    *)        echo "unknown distro: '$distro'" ; exit 1 ;;
 esac


### PR DESCRIPTION
Remove arch installation deps for pacman (https://github.com/binpash/pash/issues/328).
We should switch to PKGBUILD