### PR TITLE
Add information about the Linux Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## PaSh: Light-touch Data-Parallel Shell Processing
 > _A system for parallelizing POSIX shell scripts._
+> _Hosted by the [Linux Foundation](https://linuxfoundation.org/press-release/linux-foundation-to-host-the-pash-project-accelerating-shell-scripting-with-automated-parallelization-for-industrial-use-cases/)._
 
 Quick Jump: [Running PaSh](#running-pash) | [Installation](#installation) | [Testing](#testing) | [Repo Structure](#repo-structure) | [Community & More](#community--more)
 


### PR DESCRIPTION
Now that PaSh is [officially supported by the Linux foundation](https://linuxfoundation.org/press-release/linux-foundation-to-host-the-pash-project-accelerating-shell-scripting-with-automated-parallelization-for-industrial-use-cases/), I think this information could be added to the `README`. I used the phrase "hosted by" as it is a citation from the press release:
> The Linux Foundation, [...], today announced it will host the PaSh project.