### PR TITLE
Reduce the number of calls related to distro discovery

### DIFF
--- a/compiler/pash_init_setup.sh
+++ b/compiler/pash_init_setup.sh
@@ -1,14 +1,5 @@
-## Get distro
-## TODO: Move that somewhere where it happens once (during installation)
-if type lsb_release >/dev/null 2>&1 ; then
-    distro=$(lsb_release -i -s)
-elif [ -e /etc/os-release ] ; then
-    distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
-fi
-
-# convert to lowercase
-export distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
-
+# source the local pash config
+source ~/.pash_init
 ## File directory
 export RUNTIME_DIR=$(dirname "${BASH_SOURCE[0]}")
 ## TODO: Is there a better way to do this?

--- a/compiler/pash_ptempfile_name.sh
+++ b/compiler/pash_ptempfile_name.sh
@@ -2,13 +2,5 @@
 
 distro=${1??Distro not given}
 # now do different things depending on distro
-case "$distro" in
-    freebsd*)  
-        # bsd is so fun :)
-        tmp=$(TMPDIR=$PASH_TMP_PREFIX mktemp -t pash_XXXXXXXXXX)
-        echo "${tmp}"
-        ;;
-    *)
-        mktemp --tmpdir="$PASH_TMP_PREFIX" -u pash_XXXXXXXXXX
-        ;;
-esac
+tmp_file=$(TMPDIR=$PASH_TMP_PREFIX mktemp -t pash_XXXXXXXXXX)
+echo "${tmp_file}"

--- a/compiler/pash_ptempfile_name.sh
+++ b/compiler/pash_ptempfile_name.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 distro=${1??Distro not given}
-TMPDIR=$PASH_TMP_PREFIX mktemp -u -t pash_XXXXXXXXXX
+mktemp -u ${PASH_TMP_PREFIX}/pash_XXXXXXXXXX

--- a/compiler/pash_ptempfile_name.sh
+++ b/compiler/pash_ptempfile_name.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 
 distro=${1??Distro not given}
-# now do different things depending on distro
-tmp_file=$(TMPDIR=$PASH_TMP_PREFIX mktemp -t pash_XXXXXXXXXX)
-echo "${tmp_file}"
+TMPDIR=$PASH_TMP_PREFIX mktemp -u -t pash_XXXXXXXXXX

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -201,7 +201,6 @@ distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 case "$distro" in
     freebsd*)  
         # change sed to gsed
-        alias sed="gsed"
         sed () {
             gsed $@
         }

--- a/runtime/auto-split.sh
+++ b/runtime/auto-split.sh
@@ -8,14 +8,7 @@ n_outputs="$#"
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 
-if type lsb_release >/dev/null 2>&1 ; then
-   distro=$(lsb_release -i -s)
-elif [ -e /etc/os-release ] ; then
-   distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
-fi
-
-# convert to lowercase
-distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+distro=${1??Distro not given}
 # now do different things depending on distro
 case "$distro" in
    freebsd*)  

--- a/runtime/auto-split.sh
+++ b/runtime/auto-split.sh
@@ -8,7 +8,7 @@ n_outputs="$#"
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 # generate a temp file
-temp="$(TMPDIR=/tmp mktemp -t pash_XXXXXXXXXX)"
+temp="$(mktemp -u /tmp/pash_XXXXXXXXXX)"
 
 cat "$input" > "$temp"
 total_lines=$(wc -l $temp | cut -f 1 -d ' ')

--- a/runtime/auto-split.sh
+++ b/runtime/auto-split.sh
@@ -7,15 +7,6 @@ n_outputs="$#"
 
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
-# TODO change all auto-split calls to provide $distro as argument
-if type lsb_release >/dev/null 2>&1 ; then
-   distro=$(lsb_release -i -s)
-elif [ -e /etc/os-release ] ; then
-   distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
-fi
-
-# convert to lowercase
-distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 # generate a temp file
 temp="$(TMPDIR=/tmp mktemp -t pash_XXXXXXXXXX)"
 

--- a/runtime/auto-split.sh
+++ b/runtime/auto-split.sh
@@ -7,18 +7,17 @@ n_outputs="$#"
 
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
+# TODO change all auto-split calls to provide $distro as argument
+if type lsb_release >/dev/null 2>&1 ; then
+   distro=$(lsb_release -i -s)
+elif [ -e /etc/os-release ] ; then
+   distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
+fi
 
-distro=${1??Distro not given}
-# now do different things depending on distro
-case "$distro" in
-   freebsd*)  
-    temp="$(TMPDIR=/tmp mktemp pash_XXXXXXXXXX)"
-    ;;
-    *)
-    temp="$(mktemp --tmpdir -u pash_XXXXXXXXXX)"
-    ;;
-esac
-
+# convert to lowercase
+distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+# generate a temp file
+temp="$(TMPDIR=/tmp mktemp -t pash_XXXXXXXXXX)"
 
 cat "$input" > "$temp"
 total_lines=$(wc -l $temp | cut -f 1 -d ' ')

--- a/runtime/wait_for_output_and_sigpipe_rest.sh
+++ b/runtime/wait_for_output_and_sigpipe_rest.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
 ## TODO: Give it the output pid as an argument
-
+## TODO pass the distro version via the python script
 wait $@
+if type lsb_release >/dev/null 2>&1 ; then
+    distro=$(lsb_release -i -s)
+elif [ -e /etc/os-release ] ; then
+    distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
+fi
+
+# convert to lowercase
+distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 # now do different things depending on distro
 case "$distro" in
     freebsd*)  

--- a/runtime/wait_for_output_and_sigpipe_rest.sh
+++ b/runtime/wait_for_output_and_sigpipe_rest.sh
@@ -3,14 +3,6 @@
 ## TODO: Give it the output pid as an argument
 
 wait $@
-if type lsb_release >/dev/null 2>&1 ; then
-    distro=$(lsb_release -i -s)
-elif [ -e /etc/os-release ] ; then
-    distro=$(awk -F= '$1 == "ID" {print $2}' /etc/os-release)
-fi
-
-# convert to lowercase
-distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 # now do different things depending on distro
 case "$distro" in
     freebsd*)  

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -43,6 +43,8 @@ case "$distro" in
     ;;
 esac
 
+# save distro in the init file
+echo "export distro=$distro" > ~/.pash_init
 
 ## This was the old parser installation that required opam.
 # # Build the parser (requires libtool, m4, automake, opam)
@@ -58,7 +60,6 @@ esac
 # echo "|-- making parser..."
 # make &> $LOG_DIR/make.log
 # cd ../../
-
 
 cd ../
 


### PR DESCRIPTION
Added a local config file `~/.pash_init` that currently holds the distro information (and potentially other data we could add in the future). This file is sourced once during the bootstrap of `compiler/pash_init_setup.sh`

Signed-off-by: DIMITRIS KARNIKIS <dkarnikis@gmail.com>