### PR TITLE
Parallel Pipelines extension does not revert bash state correctly

### DIFF
--- a/compiler/config.py
+++ b/compiler/config.py
@@ -23,6 +23,8 @@ RUNTIME_EXECUTABLE = os.path.join(PASH_TOP, "compiler/pash_runtime.sh")
 assert(not os.getenv('PASH_TMP_PREFIX') is None)
 PASH_TMP_PREFIX = os.getenv('PASH_TMP_PREFIX')
 
+LOGGING_PREFIX = ""
+
 config = {}
 annotations = []
 pash_args = None
@@ -262,6 +264,8 @@ def find_next_delimiter(tokens, i):
 
 def read_vars_file(var_file_path):
     global config
+
+    log("Reading variables from:", var_file_path)
 
 
     config['shell_variables'] = None

--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -12,6 +12,9 @@ import config
 import shutil
 
 def main():
+    ## Set the logging prefix
+    config.LOGGING_PREFIX = "PaSh Preprocessor: "
+
     ## Parse arguments
     args, shell_name = parse_args()
     ## If it is interactive we need a different execution mode

--- a/compiler/pash_runtime_daemon.py
+++ b/compiler/pash_runtime_daemon.py
@@ -45,6 +45,9 @@ def parse_args():
 
 
 def init():
+    ## Set the logging prefix
+    config.LOGGING_PREFIX = "Daemon: "
+    
     args = parse_args()
     config.pash_args = args
 

--- a/compiler/util.py
+++ b/compiler/util.py
@@ -30,10 +30,10 @@ def log(*args, end='\n', level=1):
     ## as high as this log message.
     if (config.pash_args.debug >= level):
         if(config.pash_args.log_file == ""):
-            print(*args, file=sys.stderr, end=end, flush=True)
+            print(config.LOGGING_PREFIX, *args, file=sys.stderr, end=end, flush=True)
         else:
             with open(config.pash_args.log_file, "a") as f:
-                print(*args, file=f, end=end, flush=True)
+                print(config.LOGGING_PREFIX, *args, file=f, end=end, flush=True)
 
 def ptempfile():
     return tempfile.mkstemp(dir=config.PASH_TMP_PREFIX)

--- a/evaluation/tests/interface_tests/cmd_sbst.sh
+++ b/evaluation/tests/interface_tests/cmd_sbst.sh
@@ -1,0 +1,6 @@
+echo $(Testvar=set
+       unset Testvar
+       echo $Testvar${Testvar-sh_352.10}${Testvar+set}
+      )
+x=$(set one two three; echo sh_352.11 $1 $2 $3 $# $* "$@"); echo "$x"
+x=$(set one "twoA   twoB"; echo sh_352.12 $1 "$2" $3 $# $* "$@"); echo "$x"

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -4,7 +4,7 @@ export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-
 # time: print real in seconds, to simplify parsing
 
 bash="bash"
-pash="$PASH_TOP/pa.sh --pash_parallel_pipelines"
+pash="$PASH_TOP/pa.sh"
 
 output_dir="$PASH_TOP/evaluation/tests/interface_tests/output"
 mkdir -p "$output_dir"

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -4,7 +4,7 @@ export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-
 # time: print real in seconds, to simplify parsing
 
 bash="bash"
-pash="$PASH_TOP/pa.sh"
+pash="$PASH_TOP/pa.sh --pash_parallel_pipelines"
 
 output_dir="$PASH_TOP/evaluation/tests/interface_tests/output"
 mkdir -p "$output_dir"
@@ -219,6 +219,12 @@ test_cmd_sbst()
     `true; false; true; $shell cmd_sbst_subscript.sh`
 }
 
+test_cmd_sbst2()
+{
+    local shell=$1
+    $shell cmd_sbst.sh
+}
+
 test_exec_redirections()
 {
     local shell=$1
@@ -264,6 +270,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_set_e_3
     run_test test_new_line_in_var
     run_test test_cmd_sbst
+    run_test test_cmd_sbst2
     run_test test_exec_redirections
     run_test test_cat_hyphen
 else

--- a/pa.sh
+++ b/pa.sh
@@ -42,5 +42,9 @@ then
   wait 2> /dev/null 1>&2 
 fi
 
-rm -rf "${PASH_TMP_PREFIX}"
+## Don't delete the temporary directory if we are debugging
+if [ "$PASH_DEBUG_LEVEL" -eq 0 ]; then
+  rm -rf "${PASH_TMP_PREFIX}"
+fi
+
 (exit $pash_exit_code)


### PR DESCRIPTION
I resolved this. I also added `--pash_parallel_pipelines` always in interface tests even though it is experimental to make sure that it always passes all the tests.