### PR TITLE
Exposing the exit status of pash-compiled pipelines

### DIFF
--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -45,34 +45,34 @@ compile_cases = {
         }
 
 preprocess_cases = {
-    "Pipe": (lambda irFileGen, config:
-             lambda ast_node: preprocess_node_pipe(ast_node, irFileGen, config)),
-    "Command": (lambda irFileGen, config:
-                lambda ast_node: preprocess_node_command(ast_node, irFileGen, config)),
-    "Redir": (lambda irFileGen, config:
-              lambda ast_node: preprocess_node_redir(ast_node, irFileGen, config)),
-    "Background": (lambda irFileGen, config:
-                   lambda ast_node: preprocess_node_background(ast_node, irFileGen, config)),
-    "Subshell": (lambda irFileGen, config:
-                   lambda ast_node: preprocess_node_subshell(ast_node, irFileGen, config)),
-    "For": (lambda irFileGen, config:
-            lambda ast_node: preprocess_node_for(ast_node, irFileGen, config)),
-    "While": (lambda irFileGen, config:
-              lambda ast_node: preprocess_node_while(ast_node, irFileGen, config)),
-    "Defun": (lambda irFileGen, config:
-              lambda ast_node: preprocess_node_defun(ast_node, irFileGen, config)),
-    "Semi": (lambda irFileGen, config:
-             lambda ast_node: preprocess_node_semi(ast_node, irFileGen, config)),
-    "Or": (lambda irFileGen, config:
-           lambda ast_node: preprocess_node_or(ast_node, irFileGen, config)),
-    "And": (lambda irFileGen, config:
-            lambda ast_node: preprocess_node_and(ast_node, irFileGen, config)),
-    "Not": (lambda irFileGen, config:
-            lambda ast_node: preprocess_node_not(ast_node, irFileGen, config)),
-    "If": (lambda irFileGen, config:
-            lambda ast_node: preprocess_node_if(ast_node, irFileGen, config)),
-    "Case": (lambda irFileGen, config:
-             lambda ast_node: preprocess_node_case(ast_node, irFileGen, config))
+    "Pipe": (lambda irFileGen, config, last_object:
+             lambda ast_node: preprocess_node_pipe(ast_node, irFileGen, config, last_object=last_object)),
+    "Command": (lambda irFileGen, config, last_object:
+                lambda ast_node: preprocess_node_command(ast_node, irFileGen, config, last_object=last_object)),
+    "Redir": (lambda irFileGen, config, last_object:
+              lambda ast_node: preprocess_node_redir(ast_node, irFileGen, config, last_object=last_object)),
+    "Background": (lambda irFileGen, config, last_object:
+                   lambda ast_node: preprocess_node_background(ast_node, irFileGen, config, last_object=last_object)),
+    "Subshell": (lambda irFileGen, config, last_object:
+                   lambda ast_node: preprocess_node_subshell(ast_node, irFileGen, config, last_object=last_object)),
+    "For": (lambda irFileGen, config, last_object:
+            lambda ast_node: preprocess_node_for(ast_node, irFileGen, config, last_object=last_object)),
+    "While": (lambda irFileGen, config, last_object:
+              lambda ast_node: preprocess_node_while(ast_node, irFileGen, config, last_object=last_object)),
+    "Defun": (lambda irFileGen, config, last_object:
+              lambda ast_node: preprocess_node_defun(ast_node, irFileGen, config, last_object=last_object)),
+    "Semi": (lambda irFileGen, config, last_object:
+             lambda ast_node: preprocess_node_semi(ast_node, irFileGen, config, last_object=last_object)),
+    "Or": (lambda irFileGen, config, last_object:
+           lambda ast_node: preprocess_node_or(ast_node, irFileGen, config, last_object=last_object)),
+    "And": (lambda irFileGen, config, last_object:
+            lambda ast_node: preprocess_node_and(ast_node, irFileGen, config, last_object=last_object)),
+    "Not": (lambda irFileGen, config, last_object:
+            lambda ast_node: preprocess_node_not(ast_node, irFileGen, config, last_object=last_object)),
+    "If": (lambda irFileGen, config, last_object:
+            lambda ast_node: preprocess_node_if(ast_node, irFileGen, config, last_object=last_object)),
+    "Case": (lambda irFileGen, config, last_object:
+             lambda ast_node: preprocess_node_case(ast_node, irFileGen, config, last_object=last_object))
 }
 
 ir_cases = {
@@ -488,9 +488,17 @@ def compile_redirections(redirections, fileIdGen, config):
 def replace_ast_regions(ast_objects, irFileGen, config):
     preprocessed_asts = []
     candidate_dataflow_region = []
+    last_object = False
     for i, ast_object in enumerate(ast_objects):
         # log("Preprocessing AST {}".format(i))
         # log(ast_object)
+        ## If we are working on the last object we need to keep that in mind when replacing.
+        ##
+        ## The last df-region should not be executed in parallel no matter what (to not lose its exit code.)
+        if (i == len(ast_objects) - 1):
+            # log("Last object")
+            last_object = True
+
         ast, original_text, _linno_before, _linno_after = ast_object
         ## TODO: Turn the untyped ast to an AstNode
 
@@ -511,7 +519,7 @@ def replace_ast_regions(ast_objects, irFileGen, config):
         ##   then the second output is true.
         ## - If the next AST needs to be replaced too (e.g. if the current one is a background)
         ##   then the third output is true
-        preprocessed_ast_object = preprocess_node(ast, irFileGen, config)
+        preprocessed_ast_object = preprocess_node(ast, irFileGen, config, last_object=last_object)
         ## If the dataflow region is not maximal then it implies that the whole
         ## AST should be replaced.
         assert(not preprocessed_ast_object.is_non_maximal() 
@@ -538,13 +546,13 @@ def replace_ast_regions(ast_objects, irFileGen, config):
                 dataflow_region_asts, dataflow_region_lines = unzip(candidate_dataflow_region)
                 dataflow_region_text = join_original_text_lines(dataflow_region_lines)
                 replaced_ast = replace_df_region(dataflow_region_asts, irFileGen, config,
-                                                 ast_text=dataflow_region_text)
+                                                 ast_text=dataflow_region_text, disable_parallel_pipelines=last_object)
                 candidate_dataflow_region = []
                 preprocessed_asts.append(replaced_ast)
             else:
                 if(preprocessed_ast_object.should_replace_whole_ast()):
                     replaced_ast = replace_df_region([preprocessed_ast_object.ast], irFileGen, config,
-                                                     ast_text=original_text)
+                                                     ast_text=original_text, disable_parallel_pipelines=last_object)
                     preprocessed_asts.append(replaced_ast)
                 else:
                     ## In this case, it is possible that no replacement happened,
@@ -559,7 +567,7 @@ def replace_ast_regions(ast_objects, irFileGen, config):
         dataflow_region_asts, dataflow_region_lines = unzip(candidate_dataflow_region)
         dataflow_region_text = join_original_text_lines(dataflow_region_lines)
         replaced_ast = replace_df_region(dataflow_region_asts, irFileGen, config,
-                                         ast_text=dataflow_region_text)
+                                         ast_text=dataflow_region_text, disable_parallel_pipelines=True)
         candidate_dataflow_region = []
         preprocessed_asts.append(replaced_ast)
 
@@ -573,25 +581,26 @@ def join_original_text_lines(shell_source_lines_or_none):
     else:
         return "\n".join(shell_source_lines_or_none)
 
-def preprocess_node(ast_object, irFileGen, config):
+def preprocess_node(ast_object, irFileGen, config, last_object=False):
     global preprocess_cases
-    return ast_match_untyped(ast_object, preprocess_cases, irFileGen, config)
+    return ast_match_untyped(ast_object, preprocess_cases, irFileGen, config, last_object)
 
 ## This preprocesses the AST node and also replaces it if it needs replacement .
 ## It is called by constructs that cannot be included in a dataflow region.
-def preprocess_close_node(ast_object, irFileGen, config):
-    preprocessed_ast_object = preprocess_node(ast_object, irFileGen, config)
+def preprocess_close_node(ast_object, irFileGen, config, last_object=False):
+    preprocessed_ast_object = preprocess_node(ast_object, irFileGen, config, last_object=last_object)
     preprocessed_ast = preprocessed_ast_object.ast
     should_replace_whole_ast = preprocessed_ast_object.should_replace_whole_ast()
     if(should_replace_whole_ast):
-        final_ast = replace_df_region([preprocessed_ast], irFileGen, config)
+        final_ast = replace_df_region([preprocessed_ast], irFileGen, config, 
+                                      disable_parallel_pipelines=last_object)
         something_replaced = True
     else:
         final_ast = preprocessed_ast
         something_replaced = preprocessed_ast_object.will_anything_be_replaced()
     return final_ast, something_replaced
 
-def preprocess_node_pipe(ast_node, _irFileGen, _config):
+def preprocess_node_pipe(ast_node, _irFileGen, _config, last_object=False):
     ## A pipeline is *always* a candidate dataflow region.
     ## Q: Is that true?
 
@@ -603,11 +612,12 @@ def preprocess_node_pipe(ast_node, _irFileGen, _config):
     ##       there instead of
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=True,
-                                              non_maximal=ast_node.is_background)
+                                              non_maximal=ast_node.is_background,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 ## TODO: Complete this
-def preprocess_node_command(ast_node, _irFileGen, _config):
+def preprocess_node_command(ast_node, _irFileGen, _config, last_object=False):
     ## TODO: Preprocess the internals of the pipe to allow
     ##       for mutually recursive calls to PaSh.
     ##
@@ -621,31 +631,34 @@ def preprocess_node_command(ast_node, _irFileGen, _config):
         preprocessed_ast_object = PreprocessedAST(ast_node,
                                                   replace_whole=False,
                                                   non_maximal=False,
-                                                  something_replaced=False)
+                                                  something_replaced=False,
+                                                  last_ast=last_object)
         return preprocessed_ast_object
 
     ## This means we have a command. Commands are always candidate dataflow
     ## regions.
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=True,
-                                              non_maximal=False)
+                                              non_maximal=False,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 # Background of (linno * t * redirection list) 
 ## TODO: It might be possible to actually not close the inner node but rather apply the redirections on it
-def preprocess_node_redir(ast_node, irFileGen, config):
+def preprocess_node_redir(ast_node, irFileGen, config, last_object=False):
     preprocessed_node, something_replaced = preprocess_close_node(ast_node.node,
-                                                                  irFileGen, config)
+                                                                  irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.node = preprocessed_node
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=something_replaced)
+                                              something_replaced=something_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 ## TODO: Is that correct? Also, this should probably affect `semi`, `and`, and `or`
-def preprocess_node_background(ast_node, _irFileGen, _config):
+def preprocess_node_background(ast_node, _irFileGen, _config, last_object=False):
     ## A background node is *always* a candidate dataflow region.
     ## Q: Is that true?
 
@@ -653,7 +666,8 @@ def preprocess_node_background(ast_node, _irFileGen, _config):
     ##       for mutually recursive calls to PaSh.
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=True,
-                                              non_maximal=True)
+                                              non_maximal=True,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 ## TODO: We can actually preprocess the underlying node and then
@@ -663,34 +677,37 @@ def preprocess_node_background(ast_node, _irFileGen, _config):
 ##
 ##       e.g. a subshell node should also be output as a subshell in the backend.
 ## FIXME: This might not just be suboptimal, but also wrong.
-def preprocess_node_subshell(ast_node, irFileGen, config):
+def preprocess_node_subshell(ast_node, irFileGen, config, last_object=False):
     preprocessed_body, something_replaced = preprocess_close_node(ast_node.body,
-                                                                  irFileGen, config)
+                                                                  irFileGen, config,
+                                                                  last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.body = preprocessed_body
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=something_replaced)
+                                              something_replaced=something_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 ## TODO: For all of the constructs below, think whether we are being too conservative
 
 ## TODO: This is not efficient at all since it calls the PaSh runtime everytime the loop is entered.
 ##       We have to find a way to improve that.
-def preprocess_node_for(ast_node, irFileGen, config):
-    preprocessed_body, something_replaced = preprocess_close_node(ast_node.body, irFileGen, config)
+def preprocess_node_for(ast_node, irFileGen, config, last_object=False):
+    preprocessed_body, something_replaced = preprocess_close_node(ast_node.body, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.body = preprocessed_body
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=something_replaced)
+                                              something_replaced=something_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
-def preprocess_node_while(ast_node, irFileGen, config):
-    preprocessed_test, sth_replaced_test = preprocess_close_node(ast_node.test, irFileGen, config)
-    preprocessed_body, sth_replaced_body = preprocess_close_node(ast_node.body, irFileGen, config)
+def preprocess_node_while(ast_node, irFileGen, config, last_object=False):
+    preprocessed_test, sth_replaced_test = preprocess_close_node(ast_node.test, irFileGen, config, last_object=last_object)
+    preprocessed_body, sth_replaced_body = preprocess_close_node(ast_node.body, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.test = preprocessed_test
     ast_node.body = preprocessed_body
@@ -698,11 +715,12 @@ def preprocess_node_while(ast_node, irFileGen, config):
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=something_replaced)
+                                              something_replaced=something_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 ## This is the same as the one for `For`
-def preprocess_node_defun(ast_node, irFileGen, config):
+def preprocess_node_defun(ast_node, irFileGen, config, last_object=False):
     ## TODO: For now we don't want to compile function bodies
     # preprocessed_body = preprocess_close_node(ast_node.body, irFileGen, config)
     ## TODO: Could there be a problem with the in-place update
@@ -710,14 +728,17 @@ def preprocess_node_defun(ast_node, irFileGen, config):
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=False)
+                                              something_replaced=False,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 ## TODO: If the preprocessed is not maximal we actually need to combine it with the one on the right.
-def preprocess_node_semi(ast_node, irFileGen, config):
+def preprocess_node_semi(ast_node, irFileGen, config, last_object=False):
     # preprocessed_left, should_replace_whole_ast, is_non_maximal = preprocess_node(ast_node.left, irFileGen, config)
-    preprocessed_left, sth_replaced_left = preprocess_close_node(ast_node.left_operand, irFileGen, config)
-    preprocessed_right, sth_replaced_right = preprocess_close_node(ast_node.right_operand, irFileGen, config)
+    ##
+    ## TODO: Is it valid that only the right one is considered the last command?
+    preprocessed_left, sth_replaced_left = preprocess_close_node(ast_node.left_operand, irFileGen, config, last_object=False)
+    preprocessed_right, sth_replaced_right = preprocess_close_node(ast_node.right_operand, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.left_operand = preprocessed_left
     ast_node.right_operand = preprocessed_right
@@ -725,13 +746,16 @@ def preprocess_node_semi(ast_node, irFileGen, config):
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=sth_replaced)
+                                              something_replaced=sth_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
-def preprocess_node_and(ast_node, irFileGen, config):
+## TODO: Make sure that what is inside an `&&`, `||`, `!` (and others) does not run in parallel_pipelines 
+##       since we need its exit code.
+def preprocess_node_and(ast_node, irFileGen, config, last_object=False):
     # preprocessed_left, should_replace_whole_ast, is_non_maximal = preprocess_node(ast_node.left, irFileGen, config)
-    preprocessed_left, sth_replaced_left = preprocess_close_node(ast_node.left_operand, irFileGen, config)
-    preprocessed_right, sth_replaced_right = preprocess_close_node(ast_node.right_operand, irFileGen, config)
+    preprocessed_left, sth_replaced_left = preprocess_close_node(ast_node.left_operand, irFileGen, config, last_object=last_object)
+    preprocessed_right, sth_replaced_right = preprocess_close_node(ast_node.right_operand, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.left_operand = preprocessed_left
     ast_node.right_operand = preprocessed_right
@@ -739,13 +763,14 @@ def preprocess_node_and(ast_node, irFileGen, config):
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=sth_replaced)
+                                              something_replaced=sth_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
-def preprocess_node_or(ast_node, irFileGen, config):
+def preprocess_node_or(ast_node, irFileGen, config, last_object=False):
     # preprocessed_left, should_replace_whole_ast, is_non_maximal = preprocess_node(ast_node.left, irFileGen, config)
-    preprocessed_left, sth_replaced_left = preprocess_close_node(ast_node.left_operand, irFileGen, config)
-    preprocessed_right, sth_replaced_right = preprocess_close_node(ast_node.right_operand, irFileGen, config)
+    preprocessed_left, sth_replaced_left = preprocess_close_node(ast_node.left_operand, irFileGen, config, last_object=last_object)
+    preprocessed_right, sth_replaced_right = preprocess_close_node(ast_node.right_operand, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.left_operand = preprocessed_left
     ast_node.right_operand = preprocessed_right
@@ -753,26 +778,28 @@ def preprocess_node_or(ast_node, irFileGen, config):
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=sth_replaced)
+                                              something_replaced=sth_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
-def preprocess_node_not(ast_node, irFileGen, config):
+def preprocess_node_not(ast_node, irFileGen, config, last_object=False):
     # preprocessed_left, should_replace_whole_ast, is_non_maximal = preprocess_node(ast_node.left, irFileGen, config)
-    preprocessed_body, sth_replaced = preprocess_close_node(ast_node.body, irFileGen, config)
+    preprocessed_body, sth_replaced = preprocess_close_node(ast_node.body, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.body = preprocessed_body
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=sth_replaced)
+                                              something_replaced=sth_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 
-def preprocess_node_if(ast_node, irFileGen, config):
+def preprocess_node_if(ast_node, irFileGen, config, last_object=False):
     # preprocessed_left, should_replace_whole_ast, is_non_maximal = preprocess_node(ast_node.left, irFileGen, config)
-    preprocessed_cond, sth_replaced_cond = preprocess_close_node(ast_node.cond, irFileGen, config)
-    preprocessed_then, sth_replaced_then = preprocess_close_node(ast_node.then_b, irFileGen, config)
-    preprocessed_else, sth_replaced_else = preprocess_close_node(ast_node.else_b, irFileGen, config)
+    preprocessed_cond, sth_replaced_cond = preprocess_close_node(ast_node.cond, irFileGen, config, last_object=last_object)
+    preprocessed_then, sth_replaced_then = preprocess_close_node(ast_node.then_b, irFileGen, config, last_object=last_object)
+    preprocessed_else, sth_replaced_else = preprocess_close_node(ast_node.else_b, irFileGen, config, last_object=last_object)
     ## TODO: Could there be a problem with the in-place update
     ast_node.cond = preprocessed_cond
     ast_node.then_b = preprocessed_then
@@ -781,23 +808,25 @@ def preprocess_node_if(ast_node, irFileGen, config):
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=sth_replaced)
+                                              something_replaced=sth_replaced,
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
-def preprocess_case(case, irFileGen, config):
-    preprocessed_body, sth_replaced = preprocess_close_node(case["cbody"], irFileGen, config)
+def preprocess_case(case, irFileGen, config, last_object=False):
+    preprocessed_body, sth_replaced = preprocess_close_node(case["cbody"], irFileGen, config, last_object=last_object)
     case["cbody"] = preprocessed_body
     return case, sth_replaced
 
-def preprocess_node_case(ast_node, irFileGen, config):
-    preprocessed_cases_replaced = [preprocess_case(case, irFileGen, config) for case in ast_node.cases]
+def preprocess_node_case(ast_node, irFileGen, config, last_object=False):
+    preprocessed_cases_replaced = [preprocess_case(case, irFileGen, config, last_object=last_object) for case in ast_node.cases]
     preprocessed_cases, sth_replaced_cases = list(zip(*preprocessed_cases_replaced))
     ## TODO: Could there be a problem with the in-place update
     ast_node.cases = preprocessed_cases
     preprocessed_ast_object = PreprocessedAST(ast_node,
                                               replace_whole=False,
                                               non_maximal=False,
-                                              something_replaced=any(sth_replaced_cases))
+                                              something_replaced=any(sth_replaced_cases),
+                                              last_ast=last_object)
     return preprocessed_ast_object
 
 
@@ -821,7 +850,10 @@ def preprocess_node_case(ast_node, irFileGen, config):
 ## This function serializes a candidate df_region in a file, and in its place,
 ## it adds a command that calls our distribution planner with the name of the
 ## saved file.
-def replace_df_region(asts, irFileGen, config, ast_text=None):
+##
+## If we are need to disable parallel pipelines, e.g., if we are in the context of an if,
+## or if we are in the end of a script, then we set a variable.
+def replace_df_region(asts, irFileGen, config, disable_parallel_pipelines=False, ast_text=None):
     _, ir_filename = ptempfile()
 
     ## Serialize the node in a file
@@ -842,7 +874,7 @@ def replace_df_region(asts, irFileGen, config, ast_text=None):
 
     ## Replace it with a command that calls the distribution
     ## planner with the name of the file.
-    replaced_node = make_call_to_runtime(ir_filename, sequential_script_file_name)
+    replaced_node = make_call_to_runtime(ir_filename, sequential_script_file_name, disable_parallel_pipelines)
 
     return replaced_node
 
@@ -857,7 +889,8 @@ def replace_df_region(asts, irFileGen, config, ast_text=None):
 ## (MAYBE) TODO: The way I did it, is by calling the parser once, and seeing
 ## what it returns. Maybe it would make sense to call the parser on
 ## the fly to have a cleaner implementation here?
-def make_call_to_runtime(ir_filename, sequential_script_file_name) -> AstNode:
+def make_call_to_runtime(ir_filename, sequential_script_file_name,
+                         disable_parallel_pipelines) -> AstNode:
 
     ## Save the previous exit state:
     ## ```
@@ -875,6 +908,19 @@ def make_call_to_runtime(ir_filename, sequential_script_file_name) -> AstNode:
                     [make_quoted_variable("@")]]]
     input_args_command = make_command([],
                                       assignments=assignments)
+
+    ## Disable parallel pipelines if we are in the last command of the script.
+    ## ```
+    ## pash_disable_parallel_pipelines=1
+    ## ```
+    if(disable_parallel_pipelines):
+        assignments = [["pash_disable_parallel_pipelines",
+                        string_to_argument("1")]]
+    else:
+        assignments = [["pash_disable_parallel_pipelines",
+                        string_to_argument("0")]]
+    disable_parallel_pipelines_command = make_command([],
+                                                      assignments=assignments)
 
     ## Call the runtime
     arguments = [string_to_argument("source"),
@@ -907,6 +953,7 @@ def make_call_to_runtime(ir_filename, sequential_script_file_name) -> AstNode:
 
     sequence = make_semi_sequence([previous_status_command,
                                    input_args_command,
+                                   disable_parallel_pipelines_command,
                                    runtime_node,
                                    set_args_node,
                                    set_exit_status_node])

--- a/compiler/ast_util.py
+++ b/compiler/ast_util.py
@@ -2,12 +2,13 @@ from definitions.ast_node import *
 
 ## This class is used by the preprocessor in ast_to_ir
 class PreprocessedAST:
-    def __init__(self, ast, replace_whole, non_maximal, something_replaced=True):
+    def __init__(self, ast, replace_whole, non_maximal, something_replaced=True, last_ast=False):
         assert(isinstance(ast, AstNode))
         self.ast = ast
         self.replace_whole = replace_whole
         self.non_maximal = non_maximal
         self.something_replaced = something_replaced
+        self.last_ast = last_ast
 
     def should_replace_whole_ast(self):
         return self.replace_whole
@@ -17,6 +18,9 @@ class PreprocessedAST:
     
     def will_anything_be_replaced(self):
         return self.something_replaced
+
+    def is_last_ast(self):
+        return self.last_ast
 
 ## This class represents text that was not modified at all by preprocessing, and therefore does not
 ## need to be unparsed.

--- a/compiler/ir_to_ast.py
+++ b/compiler/ir_to_ast.py
@@ -110,8 +110,19 @@ def make_ir_epilogue(ephemeral_fids, clean_up_graph, log_file):
     ## Create an `rm -f` for each ephemeral fid
     call_rm_pash_funs = make_command([string_to_argument(RM_PASH_FIFOS_NAME)])
     asts.append(call_rm_pash_funs)
-    # asts += make_rms_f_prologue_epilogue(ephemeral_fids)
+
+    ## Make the following command: 
+    #    (exit $internal_exec_status)
+    exit_ec_ast = make_exit_ec_ast()
+    asts.append(exit_ec_ast)
     return asts
+
+def make_exit_ec_ast():
+    command = make_command([string_to_argument("exit"), 
+                            [make_quoted_variable("internal_exec_status")]])
+    ast = make_subshell(command)
+    return ast
+    
 
 def make_rm_f_ast(arguments):
     all_args = [string_to_argument("rm"), string_to_argument("-f")] + arguments

--- a/compiler/ir_utils.py
+++ b/compiler/ir_utils.py
@@ -190,6 +190,11 @@ def make_background(body, redirections=[]):
     node = make_kv("Background", [lineno, body, redirections])
     return node
 
+def make_subshell(body, redirections=[]):
+    lineno = 0
+    node = make_kv("Subshell", [lineno, body, redirections])
+    return node
+
 def make_command(arguments, redirections=[], assignments=[]):
     lineno = 0
     node = make_kv("Command", [lineno, assignments, arguments, redirections])

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -209,14 +209,20 @@ else
         fi
     }
 
+    ## TODO: Add a check that `set -e` is not on
+
     ## Check if there are traps set, and if so do not execute in parallel
     ##
     ## TODO: This might be an overkill but is conservative
     traps_set=$(trap)
     pash_redir_output echo "$$: (2) Traps set: $traps_set"
     # Don't fork if compilation failed. The script might have effects on the shell state.
-    if [ "$pash_runtime_return_code" -ne 0 ] || 
-       [ "$pash_parallel_pipelines" -eq 0 ] || 
+    if [ "$pash_runtime_return_code" -ne 0 ] ||
+       ## If parallel pipelines is not enabled we shouldn't fork 
+       [ "$pash_parallel_pipelines" -eq 0 ] ||
+       ## If parallel pipelines is explicitly disabled (e.g., due to context), no forking
+       [ "$pash_disable_parallel_pipelines" -eq 1 ] ||
+       ## If traps are set, no forking
        [ ! -z "$traps_set" ] ||
        [ "$pash_daemon" -eq 0 ]; then
         # Early clean up in case the script effects shell like "break" or "exec"

--- a/evaluation/benchmarks/runtime-overhead/for-echo.sh
+++ b/evaluation/benchmarks/runtime-overhead/for-echo.sh
@@ -3,3 +3,4 @@ for i in $(seq $N)
 do
         echo $i
 done
+echo "end"

--- a/evaluation/tests/interface_tests/cat-redir-fail.sh
+++ b/evaluation/tests/interface_tests/cat-redir-fail.sh
@@ -1,0 +1,1 @@
+cat < no.such.file

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -255,6 +255,12 @@ test_set-dash()
     grep 'echo hello' set-dash-v-x.err | wc -l
 }
 
+test_cat_redir_fail()
+{
+    local shell=$1
+    $shell cat-redir-fail.sh
+}
+
 ## We run all tests composed with && to exit on the first that fails
 if [ "$#" -eq 0 ]; then
     run_test test1
@@ -288,6 +294,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_cat_hyphen
     run_test test_trap
     run_test test_set-dash
+    run_test test_cat_redir_fail
 else
     for testname in $@
     do

--- a/runtime/wait_for_output_and_sigpipe_rest.sh
+++ b/runtime/wait_for_output_and_sigpipe_rest.sh
@@ -3,6 +3,10 @@
 ## TODO: Give it the output pid as an argument
 wait $@
 
+## TODO: This only works if there is only a single output node 
+##         (and a single node given as an argument to `wait`).
+export internal_exec_status=$?
+
 # It is assumed that $distro is set when this is called.
 
 # Note: We need the || true after the grep so that it doesn't exit with error if it finds nothing.
@@ -23,10 +27,3 @@ do
     # wait $pid
     (> /dev/null 2>&1 kill -SIGPIPE $pid || true)
 done
-
-## Only wait if that is not empty
-# if [ ! -z "$var" ];
-# then
-#     ## Need to wait to not leave any zombies
-#     wait
-# fi


### PR DESCRIPTION
This PR tries to add support for returning the exit status of pash-compiled pipelines. These changes fix the issue in general but there is still a failure with `--parallel_pipelines` since this flag executes pipelines in the background and therefore their exit status is lost.

@mgree, @tammam1998 the problem is here: https://github.com/binpash/pash/blob/cat-redir-fail/compiler/pash_runtime.sh#L233. Is there any way to address this without losing support for parallel pipelines?