### PR TITLE
Remove help from daemon so that it doesn't get stuck

### DIFF
--- a/compiler/pash_runtime_daemon.py
+++ b/compiler/pash_runtime_daemon.py
@@ -31,7 +31,7 @@ def handler(signum, frame):
 signal.signal(signal.SIGTERM, handler)
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     config.add_common_arguments(parser)
     args, unknown_args = parser.parse_known_args()
 


### PR DESCRIPTION
Fix a bug where pash gets stuck when invoked using `--help`.

```sh
pa.sh --help
```