### PR TITLE
Livestar fixes

### DIFF
--- a/compiler/pash_init_setup.sh
+++ b/compiler/pash_init_setup.sh
@@ -195,7 +195,7 @@ else
         maximum_retries=100
         ## For some reason, `nc -z` doesn't work on livestar (it always returns error)
         ## and therefore we need to send something. 
-        until  echo "Daemon Start" | nc -U "$DAEMON_SOCKET" >/dev/null 2>&1 ; 
+        until  echo "Daemon Start" 2> /dev/null | nc -U "$DAEMON_SOCKET" >/dev/null 2>&1 ; 
         do 
             ## TODO: Can we wait for the daemon in a better way?
             sleep 0.01

--- a/compiler/pash_init_setup.sh
+++ b/compiler/pash_init_setup.sh
@@ -193,7 +193,9 @@ else
         i=0
         ## This is a magic number to make sure that we wait enough
         maximum_retries=100
-        while ! nc -z -U "$DAEMON_SOCKET" >/dev/null 2>&1 ; 
+        ## For some reason, `nc -z` doesn't work on livestar (it always returns error)
+        ## and therefore we need to send something. 
+        until  echo "Daemon Start" | nc -U "$DAEMON_SOCKET" >/dev/null 2>&1 ; 
         do 
             ## TODO: Can we wait for the daemon in a better way?
             sleep 0.01

--- a/compiler/pash_runtime_daemon.py
+++ b/compiler/pash_runtime_daemon.py
@@ -236,7 +236,7 @@ class Scheduler:
             ## to signify that we are done.
             self.respond("All finished")
             self.done = True
-        elif (input_cmd == ""):
+        elif (input_cmd.startswith("Daemon Start") or input_cmd == ""):
             ## This happens when pa.sh first connects to daemon to see if it is on
             self.close_last_connection()
         else:

--- a/evaluation/benchmarks/run.par.sh
+++ b/evaluation/benchmarks/run.par.sh
@@ -9,13 +9,14 @@ if [[ -z "$PASH_TOP" ]]; then
 fi
 
 oneliners_pash(){
-  par_times_file="par.res"
-  par_outputs_suffix="par.out"
+  times_file="par.res"
+  outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
-  if [ -e "oneliners/$par_times_file" ]; then
-    echo "skipping oneliners/$par_times_file"
+  if [ -e "oneliners/$times_file" ]; then
+    echo "skipping oneliners/$times_file"
     return 0
   fi
   
@@ -41,9 +42,9 @@ oneliners_pash(){
     "shortest-scripts;all_cmdsx100.txt"
   )
 
-  touch "$par_times_file"
-  echo executing one-liners with pash $(date) | tee -a "$par_times_file"
-  echo '' >> "$par_times_file"
+  touch "$times_file"
+  echo executing one-liners with pash $(date) | tee -a "$times_file"
+  echo '' >> "$times_file"
 
   for script_input in ${scripts_inputs[@]}
   do
@@ -55,10 +56,13 @@ oneliners_pash(){
     padded_script="${script}.sh:${pad}"
     padded_script=${padded_script:0:30}
 
-    par_outputs_file="${outputs_dir}/${script}.${par_outputs_suffix}"
+    outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS  --log_file "${pash_log}" ${script}.sh > "$par_outputs_file"; } 2>&1) | tee -a "$par_times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
 
   cd ..
@@ -67,6 +71,7 @@ oneliners_pash(){
 unix50_pash(){
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -101,8 +106,11 @@ unix50_pash(){
 
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done  
   cd ..
 }
@@ -110,6 +118,7 @@ unix50_pash(){
 web-index_pash(){
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -134,15 +143,19 @@ web-index_pash(){
   export WIKI=$PASH_TOP/evaluation/benchmarks/web-index/input/
   outputs_file="${outputs_dir}/web-index.${outputs_suffix}"
   pash_log="${pash_logs_dir}/web-index.pash.log"
+  single_time_file="${outputs_dir}/web-index.${time_suffix}"
 
   ## FIXME: There is a bug when running with r_split at the moment. r_wrap cannot execute bash_functions
-  echo web-index.sh: $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" web-index.sh > "${outputs_file}"; } 2>&1) | tee -a "$times_file"
+  echo -n "web-index.sh:" | tee -a "$times_file"
+  time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" web-index.sh > "$outputs_file" 2> "${single_time_file}"
+  cat "${single_time_file}" | tee -a "$times_file"
   cd ..
 }
 
 max-temp_pash(){
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -160,13 +173,18 @@ max-temp_pash(){
   echo executing max temp with pash $(date) | tee -a "$times_file"
   outputs_file="${outputs_dir}/max-temp.${outputs_suffix}"
   pash_log="${pash_logs_dir}/max-temp.pash.log"
-  echo mex-temp.sh: $({ time time "$PASH_TOP/pa.sh"  -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" max-temp.sh > "${outputs_file}"; } 2>&1) | tee -a "$times_file"
+  single_time_file="${outputs_dir}/max-temp.${time_suffix}"
+
+  echo -n "max-temp.sh:" | tee -a "$times_file"
+  time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" max-temp.sh > "$outputs_file" 2> "${single_time_file}"
+  cat "${single_time_file}" | tee -a "$times_file"
   cd ..
 }
 
 analytics-mts_pash(){
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -199,8 +217,11 @@ analytics-mts_pash(){
     export IN="input/in.csv"
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
 }
@@ -208,6 +229,7 @@ analytics-mts_pash(){
 poets_pash(){
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -267,8 +289,11 @@ poets_pash(){
 
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
 }
@@ -282,6 +307,7 @@ dgsh_pash(){
 
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -343,8 +369,11 @@ dgsh_pash(){
 
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
 }
@@ -354,6 +383,7 @@ aliases_pash(){
 
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -409,8 +439,11 @@ aliases_pash(){
 
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
 }
@@ -421,6 +454,7 @@ posh_pash(){
 
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -461,8 +495,11 @@ posh_pash(){
 
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
 }
@@ -471,6 +508,7 @@ bio_pash(){
 
   times_file="par.res"
   outputs_suffix="par.out"
+  time_suffix="par.time"
   outputs_dir="outputs"
   pash_logs_dir="pash_logs"
   width=16
@@ -508,8 +546,11 @@ bio_pash(){
 
     outputs_file="${outputs_dir}/${script}.${outputs_suffix}"
     pash_log="${pash_logs_dir}/${script}.pash.log"
+    single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
-    echo "${padded_script}" $({ time "$PASH_TOP/pa.sh" -d 1 -w "${width}"  $PASH_FLAGS --log_file "${pash_log}" ${script}.sh > "$outputs_file"; } 2>&1) | tee -a "$times_file"
+    echo -n "${padded_script}" | tee -a "$times_file"
+    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
 }

--- a/evaluation/tests/spell-grep.sh
+++ b/evaluation/tests/spell-grep.sh
@@ -4,7 +4,7 @@ set_diff()
 }
 
 dict=$PASH_TOP/evaluation/tests/input/sorted_words
-IN=$PASH_TOP/evaluation/tests/input/10M.txt
+IN=$PASH_TOP/evaluation/tests/input/1M.txt
 
 cat $IN |
     # groff -t -e -mandoc -Tascii |  # remove formatting commands


### PR DESCRIPTION
This PR contains fixes or changes so that pash works on livestar.

1. It modifies `nc -z` to not use that flag to check if daemon is listening since for some reason, the `nc` version on livestar always returns 1 even if it is connected.
2. Modifies test input for `spell-grep` for tests to take reasonable time.