### PR TITLE
Disable debugging when running benchmarks by default

### DIFF
--- a/evaluation/benchmarks/run.par.sh
+++ b/evaluation/benchmarks/run.par.sh
@@ -61,7 +61,7 @@ oneliners_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
 
@@ -109,7 +109,7 @@ unix50_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done  
   cd ..
@@ -147,7 +147,7 @@ web-index_pash(){
 
   ## FIXME: There is a bug when running with r_split at the moment. r_wrap cannot execute bash_functions
   echo -n "web-index.sh:" | tee -a "$times_file"
-  time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" web-index.sh > "$outputs_file" 2> "${single_time_file}"
+  time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" web-index.sh > "$outputs_file" 2> "${single_time_file}"
   cat "${single_time_file}" | tee -a "$times_file"
   cd ..
 }
@@ -176,7 +176,7 @@ max-temp_pash(){
   single_time_file="${outputs_dir}/max-temp.${time_suffix}"
 
   echo -n "max-temp.sh:" | tee -a "$times_file"
-  time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" max-temp.sh > "$outputs_file" 2> "${single_time_file}"
+  time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" max-temp.sh > "$outputs_file" 2> "${single_time_file}"
   cat "${single_time_file}" | tee -a "$times_file"
   cd ..
 }
@@ -220,7 +220,7 @@ analytics-mts_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
@@ -292,7 +292,7 @@ poets_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
@@ -372,7 +372,7 @@ dgsh_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
@@ -442,7 +442,7 @@ aliases_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
@@ -498,7 +498,7 @@ posh_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..
@@ -549,7 +549,7 @@ bio_pash(){
     single_time_file="${outputs_dir}/${script}.${time_suffix}"
 
     echo -n "${padded_script}" | tee -a "$times_file"
-    time "$PASH_TOP/pa.sh" -d 1 -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
+    time "$PASH_TOP/pa.sh" -w "${width}" $PASH_FLAGS   --log_file "${pash_log}" ${script}.sh > "$outputs_file" 2> "${single_time_file}"
     cat "${single_time_file}" | tee -a "$times_file"
   done
   cd ..

--- a/evaluation/benchmarks/run_all_benchmarks.sh
+++ b/evaluation/benchmarks/run_all_benchmarks.sh
@@ -3,11 +3,16 @@
 ## Determines whether the experimental pash flags will be tested. 
 ## By default they are not.
 export EXPERIMENTAL=0
+export DEBUG=0
 
 for item in $@
 do
     if [ "--experimental" == "$item" ]; then
         export EXPERIMENTAL=1
+    fi
+
+    if [ "--debug" == "$item" ]; then
+        export DEBUG=1
     fi
 done
 
@@ -31,6 +36,11 @@ if [ "$EXPERIMENTAL" -eq 1 ]; then
   # --speculation quick_abort is not maintained at the moment 
 else
   export PASH_FLAGS=""
+fi
+
+## Add the debug flag
+if [ "$DEBUG" -eq 1 ]; then
+  export PASH_FLAGS="$PASH_FLAGS -d 1"
 fi
 
 


### PR DESCRIPTION
Let's not run `-d 1` by default when running benchmarks, since debugging adds significant overhead. @dkarnikis we should make sure to run experiments from now without `-d 1`. If you need to get a log to debug, you can call `run_all_benchmarks.sh` with `--debug`.