### PR TITLE
change default r_split batch size param

### DIFF
--- a/compiler/config.py
+++ b/compiler/config.py
@@ -111,8 +111,8 @@ def add_common_arguments(parser):
                         action="store_true")
     parser.add_argument("--r_split_batch_size",
                         type=int,
-                        help="(experimental) configure the batch size of r_splti (default: 100KB)",
-                        default=100000)
+                        help="(experimental) configure the batch size of r_split (default: 1MB)",
+                        default=1000000)
     parser.add_argument("--dgsh_tee",
                         help="(experimental) use dgsh-tee instead of eager",
                         action="store_true")


### PR DESCRIPTION
Changed the default param just in case we ever forget to add --r_split_batch_size 1000000