### PR TITLE
Fix an issue with diff annotation

### DIFF
--- a/annotations/diff.json
+++ b/annotations/diff.json
@@ -4,7 +4,7 @@
     [
         {
             "predicate": "default",
-            "class": "non-pure",
+            "class": "pure",
             "inputs": ["args[:]"],
             "outputs": ["stdout"]
         }


### PR DESCRIPTION
@nvasilakis  Can you think of a reason why we had `diff` be non-pure? I don't see why `diff` is not pure by default.

@dkarnikis after/if we merge this we should rerun `oneliners/diff.sh`

