### PR TITLE
fix bug caused by early kill of process

### DIFF
--- a/runtime/r_merge.c
+++ b/runtime/r_merge.c
@@ -45,10 +45,8 @@ void MergeInput(char *inputFileNames[], unsigned int numInputFiles)
     // fprintf(stderr, "start reading block %ld\n", id);
     while (tot_read < blockSize) {
         readSize = MIN(bufLen, blockSize-tot_read);
-        if (fread(buffer, 1, readSize, blockBuf[bufferIdx].inputFile) != readSize)
-        {
-          err(2, "r_merge: There is a problem with the merge files head data");
-        }
+
+        readSize = handle_reading(buffer, readSize, blockBuf[bufferIdx].inputFile);
         
         tot_read += readSize;
         safeWrite(buffer, 1, readSize, stdout);

--- a/runtime/r_split.h
+++ b/runtime/r_split.h
@@ -116,3 +116,20 @@ void writeHeader(FILE *destFile, int64_t id, size_t blockSize, bool isLast)
   block_header header = {id, blockSize, isLast};
   safeWrite((char *)&header, sizeof(block_header), 1, destFile);
 }
+
+size_t handle_reading(char *buffer, size_t size, FILE* stream) {
+  size_t len = 0;
+  // size_t readSize = MIN(bufLen, blockSize-total_read);
+  if (size && (len = fread(buffer, 1, size, stream)) != size)
+  {   
+    // This fixes a problem that happens sometimes when pash kill signal effects the process we were reading from but not the current process
+    // Might need to extend this to gracefully exit if errno == SIGPIPE
+    if (feof(stream) && !errno) {
+        PRINTDBG("Pipe closed before the full block data was written")
+        exit(0);
+    } else {
+        err(2, "There is a problem with reading the block");
+    }
+  }
+  return len;
+}

--- a/runtime/r_unwrap.c
+++ b/runtime/r_unwrap.c
@@ -13,9 +13,7 @@ void unwrap(FILE* inputFile) {
         size_t tot_read = 0, readSize = 0;
         while (tot_read < blockSize) {
             readSize = MIN(bufLen, blockSize-tot_read);
-            if (fread(buffer, 1, readSize, stdin) != readSize) {
-                err(2, "There is a problem with reading the block");
-            }
+            handle_reading(buffer, readSize, stdin);
             
             //Write to forked process
             safeWrite(buffer, 1, readSize, stdout);

--- a/runtime/r_wrap.c
+++ b/runtime/r_wrap.c
@@ -88,10 +88,8 @@ void processCmd(char *args[])
             while (tot_read < blockSize || currWriteLen > 0 || !isLast)
             {
                 readSize = MIN(bufLen, blockSize - tot_read);
-                if (readSize && fread(buffer, 1, readSize, stdin) != readSize)
-                {
-                    err(2, "There is a problem with reading the block");
-                }
+                handle_reading(buffer, readSize, stdin);
+                
                 if ((currWriteLen + readSize) > writeBufLen) {
                     writeBufLen = 2*(currWriteLen + readSize);
                     writebuffer = realloc(writebuffer, writeBufLen+1);


### PR DESCRIPTION
This is a rare bug that happens sometimes when some processes terminate before the sigterm signal reaches other processes. This bug happens non deterministically (only sometimes) on 20.sh and 34.sh with width 16.