### PR TITLE
Kill processes that are exclusively under the current process tree

### DIFF
--- a/pa.sh
+++ b/pa.sh
@@ -4,7 +4,16 @@ export PASH_TOP=${PASH_TOP:-${BASH_SOURCE%/*}}
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 # point to the local downloaded folders
 export PYTHONPATH=${PASH_TOP}/python_pkgs/
+## Register the signal handlers, we can add more signals here
+trap kill_all SIGTERM SIGINT
 
+## kill all the pending processes that are spawned by this shell
+function kill_all() {
+    # kill all my subprocesses only
+    kill -s SIGKILL 0
+    # kill pash_daemon
+    kill -s SIGKILL $daemon_pid
+}
 ## Save the umask to first create some files and then revert it
 old_umask=$(umask)
 


### PR DESCRIPTION
- Kill pending processes running under the current instance of pash (killed by signal)
- Doesn't affect the performance of other running pash instances

(Moved from https://github.com/binpash/pash/pull/454)

Signed-off-by: Dimitris Karnikis <dkarnikis@gmail.com>