### PR TITLE
Fix link to guide for contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ Mailing Lists:
 * [pash-commits](https://groups.google.com/g/pash-commits): Join this mailing list for commit notifications
 
 Development/contributions:
-* Contribution guide: [docs/contrib](docs/contrib)
+* Contribution guide: [docs/contributing](docs/contributing/contrib.md)
 * Continuous Integration Server: [ci.binpa.sh](http://ci.binpa.sh)


### PR DESCRIPTION
The link was broken and since there is only one single file in the directory, I changed it to point it to this one.