### PR TITLE
Fix input file for shortest scripts, i.e., make it all_cmds

### DIFF
--- a/evaluation/benchmarks/oneliners/shortest-scripts.sh
+++ b/evaluation/benchmarks/oneliners/shortest-scripts.sh
@@ -6,6 +6,6 @@
 
 # FIX: Input here should be a set of commands, more precisely, the ones on this specific machine.
 
-IN=${IN:-$PASH_TOP/evaluation/benchmarks/oneliners/input/1G.txt}
+IN=${IN:-$PASH_TOP/evaluation/benchmarks/oneliners/input/all_cmds.txt}
 
 cat $IN | xargs file | grep "shell script" | cut -d: -f1 | xargs -L 1 wc -l | grep -v '^0$' | sort -n | head -15


### PR DESCRIPTION
The original file was not a list of commands and does not really make sense for the script I think. From the input folder, the file `all_cmds.txt` was reasonable to choose but I do not exactly know whether this was the original intention.
Signed-off-by: Felix Stutz <fstutz@mpi-sws.org>