### PR TITLE
Fix bug causing graph compilation to fail if termination clean_up_graph flag wasn't set

### DIFF
--- a/compiler/ir_to_ast.py
+++ b/compiler/ir_to_ast.py
@@ -115,8 +115,9 @@ def make_ir_epilogue(ephemeral_fids, clean_up_graph, log_file):
         asts.append(com)
     else:
         ## Otherwise we just wait for all processes to die.
-        wait_com = make_command(string_to_argument('wait'))
-        asts.append(wait_com)
+        wait_com = make_command([string_to_argument('wait')])
+        exit_status = make_command([string_to_argument("internal_exec_status=$?")])
+        asts.extend([wait_com, exit_status])
 
     ## Create an `rm -f` for each ephemeral fid
     call_rm_pash_funs = make_command([string_to_argument(RM_PASH_FIFOS_NAME)])


### PR DESCRIPTION
If the user doesn't set termination to clean_up_graph, the compiler tries to add a `wait` command to wait for all processes. However, there was a bug in how we added the wait command which causes the compilation to fail. We also didn't report `internal_exec_status` after `wait` which is required at the end of the generated script.