### PR TITLE
Broken eval

### DIFF
--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -221,8 +221,8 @@ esac
 echo "group,Bash,Pash2,Pash8" > ${results_time}
 paste -d'@' $test_results_dir/results.time_*  | sed 's\,\.\g' | sed 's\:\,\g' | sed 's\@\,\g' >> ${results_time}
 
-echo "Below follow the identical outputs:"
-grep "are identical" "$test_results_dir"/result_status | awk '{print $1}'
+#echo "Below follow the identical outputs:"
+#grep "are identical" "$test_results_dir"/result_status | awk '{print $1}'
 
 echo "Below follow the non-identical outputs:"     
 grep "are not identical" "$test_results_dir"/result_status | awk '{print $1}'

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -107,14 +107,15 @@ execute_pash_and_check_diff() {
 
         { time "$PASH_TOP/pa.sh" $@ ; } 1> "$pash_output" 2>> "${pash_time}" &&
         b=$(cat "$pash_time"); 
-        test_diff_ec=0
-        $(diff "$seq_output" "$pash_output" || test_diff_ec=$?)
-        echo "$c$b" > "${pash_time}"
+        test_diff_ec=$(cmp -s "$seq_output" "$pash_output" && echo 0 || echo 1)
         # differ
         script=$(basename $script_to_execute)
         if [ $test_diff_ec -ne 0 ]; then
+            c=$(diff -s "$seq_output" "$pash_output" | head)
+            echo "$c$b" > "${pash_time}"
             echo "$script are not identical" >> $test_results_dir/result_status
         else
+            echo "Files $seq_output and $pash_output are identical" > "${pash_time}"
             echo "$script are identical" >> $test_results_dir/result_status
         fi
 

--- a/evaluation/benchmarks/dependency_untangling/input/install-deps.sh
+++ b/evaluation/benchmarks/dependency_untangling/input/install-deps.sh
@@ -1,7 +1,7 @@
 IN=$PASH_TOP/evaluation/benchmarks/dependency_untangling/input/
 mkdir -p ${IN}/deps/
 # install dependencies
-pkgs='ffmpeg unrtf imagemagick libarchive-tools zstd liblzma-dev libbz2-dev zip unzip nodejs'
+pkgs='ffmpeg unrtf imagemagick libarchive-tools zstd liblzma-dev libbz2-dev zip unzip nodejs tcpdump'
 
 if ! dpkg -s $pkgs >/dev/null 2>&1 ; then
     sudo apt-get install $pkgs -y

--- a/evaluation/benchmarks/dependency_untangling/input/setup.sh
+++ b/evaluation/benchmarks/dependency_untangling/input/setup.sh
@@ -42,12 +42,8 @@ setup_dataset() {
   fi
   
   if [ ! -d ${IN}/wav ]; then
-      mkdir -p ${IN}/wav
-      cd ${IN}/wav
-      wget https://file-examples-com.github.io/uploads/2017/11/file_example_WAV_1MG.wav
-      wget https://file-examples-com.github.io/uploads/2017/11/file_example_WAV_2MG.wav
-      wget https://file-examples-com.github.io/uploads/2017/11/file_example_WAV_5MG.wav
-      wget https://file-examples-com.github.io/uploads/2017/11/file_example_WAV_10MG.wav
+      wget http://pac-n4.csail.mit.edu:81/pash_data/wav.zip
+      unzip wav.zip && cd wav/
       for f in *.wav; do
           FILE=$(basename "$f")
           for (( i = 0; i <= $WAV_DATA_FILES; i++)) do

--- a/evaluation/eval_script/run_all.sh
+++ b/evaluation/eval_script/run_all.sh
@@ -62,7 +62,8 @@ function run_all_benchmarks() {
   cd ${PASH_TOP}/evaluation/benchmarks
   # remove all res files from previous runs
   find . -type d -name "outputs" | xargs rm -rf
-  find . -type d -name "output" | xargs rm -rf
+  # do not remove any input from the node_modules dataset
+  find . -type d -not -path "*/node_modules/*" -name "output" | xargs rm -rf 
   find . -type d -name "pash_logs" | xargs rm -rf
   find . -type f -name "*.res" | xargs rm -f
   # start preparing from execution


### PR DESCRIPTION
1. Install missing package for log processing benchmark (tcpdump)
2. Replace dead links for media conversion benchmark

Signed-off-by: Dimitris Karnikis <dkarnikis@gmail.com>