### PR TITLE
HDFS cat support

### DIFF
--- a/annotations/hdfs.json
+++ b/annotations/hdfs.json
@@ -1,0 +1,23 @@
+{
+    "command": "hdfs",
+    "cases":
+    [
+        {
+            "predicate":
+            {
+                "operator": "exists",
+                "operands": ["-cat"]
+            },
+            "class": "stateless",
+            "inputs": ["args[1]"],
+            "outputs": ["stdout"],
+			"comments": "This represents hdfs dfs -cat <path>. Slightly hacky since we only check for -cat"
+        },
+        {
+            "predicate": "default",
+            "class": "side-effectful",
+            "inputs": ["stdin"],
+            "outputs": ["stdout"]
+        }
+    ]
+}

--- a/compiler/definitions/ir/file_id.py
+++ b/compiler/definitions/ir/file_id.py
@@ -102,6 +102,9 @@ class FileId:
     def has_file_descriptor_resource(self):
         return (isinstance(self.resource, FileDescriptorResource))
 
+    def has_remote_file_resource(self):
+        return isinstance(self.resource, HDFSFileResource)
+
     def is_ephemeral(self):
         return (isinstance(self.resource, EphemeralResource))
 
@@ -118,3 +121,13 @@ class FileId:
 
     def get_ident(self):
         return self.ident
+
+    def is_available_on(self, host):
+        if self.is_ephemeral():
+            return True
+        elif self.has_remote_file_resource():
+            return self.resource.is_available_on(host)
+        else:
+            # Currently any other resource types should
+            # be part of the main shell graph.
+            return False

--- a/compiler/definitions/ir/file_id.py
+++ b/compiler/definitions/ir/file_id.py
@@ -103,7 +103,7 @@ class FileId:
         return (isinstance(self.resource, FileDescriptorResource))
 
     def has_remote_file_resource(self):
-        return isinstance(self.resource, HDFSFileResource)
+        return isinstance(self.resource, RemoteFileResource)
 
     def is_ephemeral(self):
         return (isinstance(self.resource, EphemeralResource))

--- a/compiler/definitions/ir/nodes/hdfs_cat.py
+++ b/compiler/definitions/ir/nodes/hdfs_cat.py
@@ -1,0 +1,11 @@
+from definitions.ir.dfg_node import *
+
+class HDFSCat(DFGNode):
+    def __init__(self, inputs, outputs, com_name, com_category,
+                 com_options = [], com_redirs = [], com_assignments=[]):
+        assert(str(com_name) == "hdfs")
+        assert(str(com_options[0][1]) == "dfs" and str(com_options[1][1]) == "-cat") 
+        super().__init__(inputs, outputs, com_name, com_category,
+                         com_options=com_options, 
+                         com_redirs=com_redirs, 
+                         com_assignments=com_assignments)

--- a/compiler/definitions/ir/resource.py
+++ b/compiler/definitions/ir/resource.py
@@ -1,6 +1,7 @@
 from definitions.ir.arg import *
 from util import *
 from ir_utils import *
+import socket
 
 ## TODO: Resources should probably be more elaborate than just a
 ## string and a line range. They could be URLs, and possibly other things.
@@ -56,3 +57,46 @@ class FileResource(Resource):
 class EphemeralResource(Resource):
     def __init__(self):
         self.uri = None
+
+class RemoteFileResource(Resource):
+    def __init__(self):
+        raise Exception("RemoteFileResource is an interface")
+
+    def __str__(self):
+        raise Exception("RemoteFileResource is an interface")
+
+    def _normalize_addr(self, addr):
+        """
+        Helper, removes port number if supplied in address and normalizes host address
+        Example1: datanode1 -> 172.18.0.3
+        Example2: 172.18.0.3:5555 -> 172.18.0.3
+        """
+        host = addr.rsplit(":", 1)[0]
+        normalized_host = socket.gethostbyaddr(host)[2][0]
+        return normalized_host
+
+class HDFSFileResource(RemoteFileResource):
+    ## The uri is the path of the file.
+    def __init__(self, uri, resource_hosts):
+        """
+        Params:
+            uri: Usually the path to the file
+            resource_hosts: the addresses of all the machines containing 
+            the resource.
+        """
+        self.uri = uri
+        self.hosts = list(map(self._normalize_addr, resource_hosts))
+
+    def __eq__(self, other):
+        if isinstance(other, HDFSFileResource):
+            return self.uri == other.uri
+        return False
+
+    def is_available_on(self, host):
+        return host in self.hosts
+
+    def __repr__(self):
+        return f'hdfs://{str(self.uri)}'
+        
+    def __str__(self):
+        return f"$HDFS_DATANODE_DIR/{str(self.uri)}"

--- a/compiler/definitions/ir/resource.py
+++ b/compiler/definitions/ir/resource.py
@@ -60,10 +60,13 @@ class EphemeralResource(Resource):
 
 class RemoteFileResource(Resource):
     def __init__(self):
-        raise Exception("RemoteFileResource is an interface")
+        raise NotImplementedError("RemoteFileResource is an interface")
 
     def __str__(self):
-        raise Exception("RemoteFileResource is an interface")
+        raise NotImplementedError("RemoteFileResource is an interface")
+
+    def is_available_on(self, host):
+        raise NotImplementedError("RemoteFileResource is an interface")
 
     def _normalize_addr(self, addr):
         """
@@ -97,6 +100,6 @@ class HDFSFileResource(RemoteFileResource):
 
     def __repr__(self):
         return f'hdfs://{str(self.uri)}'
-        
+
     def __str__(self):
         return f"$HDFS_DATANODE_DIR/{str(self.uri)}"

--- a/compiler/definitions/ir/resource.py
+++ b/compiler/definitions/ir/resource.py
@@ -83,7 +83,9 @@ class HDFSFileResource(RemoteFileResource):
     def __init__(self, uri, resource_hosts):
         """
         Params:
-            uri: Usually the path to the file
+            uri: Usually the path to the file. The path doesn't include the top directory 
+            which is different between hosts. The str function adds the prefix $HDFS_DATANODE_DIR/ 
+            which should be defined on host machine worker environment.
             resource_hosts: the addresses of all the machines containing 
             the resource.
         """
@@ -99,7 +101,7 @@ class HDFSFileResource(RemoteFileResource):
         return host in self.hosts
 
     def __repr__(self):
-        return f'hdfs://{str(self.uri)}'
+        return f'hdfs://{self.uri}'
 
     def __str__(self):
-        return f"$HDFS_DATANODE_DIR/{str(self.uri)}"
+        return f"$HDFS_DATANODE_DIR/{self.uri}"

--- a/compiler/dspash/hdfs_file_data.py
+++ b/compiler/dspash/hdfs_file_data.py
@@ -2,13 +2,13 @@ import os
 import subprocess
 import sys
 
-
 class FileData(object):
-    def __init__(self):
+    def __init__(self, filename):
         self.blocknames = []
         self.dnodenames = []
         self.machines = []
         self.size = 0
+        self._getinfo(filename)
         # self.dnodepath = subprocess.check_output("hdfs getconf -confKey dfs.datanode.data.dir", shell=True).decode("utf-8").strip("\n")
         # if (self.dnodepath.startswith("file://")):
         #    self.dnodepath = self.dnodepath[len("file://"):]
@@ -32,8 +32,37 @@ class FileData(object):
             )
         return filepaths
 
+    def _getinfo(self, filename):
+        info = self
+        log = subprocess.check_output(
+            "hdfs fsck {0} -files -blocks -locations".format(filename), shell=True, stderr=subprocess.PIPE
+        )
+        count = 0
+        for line in log.splitlines():
+            wordarr = line.split()
+            if len(wordarr) > 0 and wordarr[0].decode("utf-8") == filename and count == 0:
+                info.size = int(wordarr[1])
+                count += 1
+            elif (
+                len(wordarr) > 0
+                and count > 0
+                and wordarr[0][:-1].isdigit()
+                and int(wordarr[0][:-1]) == count - 1
+            ):
+                count += 1
+                rawinfo = wordarr[1].decode("utf-8").split(":")
+                info.blocknames.append(rawinfo[1][0 : rawinfo[1].rfind("_")])
+                info.dnodenames.append(rawinfo[0])
+                stline = line.decode("utf-8")
+                info.machines.append(
+                    _getIPs(stline[stline.find("DatanodeInfoWithStorage") - 1 :])
+                )
+        assert len(info.blocknames) != 0
+        assert len(info.dnodenames) != 0
+        assert info.size > 0
+        return info
 
-def getIPs(raw):
+def _getIPs(raw):
     rawparts = raw.split(" ")
     ips = []
     for part in rawparts:
@@ -41,42 +70,10 @@ def getIPs(raw):
         ips.append(part[index + len("DatanodeInfoWithStorage") + 1 : part.find(",")])
     return ips
 
-
-def getinfo(filename):
-    info = FileData()
-    log = subprocess.check_output(
-        "hdfs fsck {0} -files -blocks -locations".format(filename), shell=True
-    )
-    count = 0
-    for line in log.splitlines():
-        wordarr = line.split()
-        if len(wordarr) > 0 and wordarr[0].decode("utf-8") == filename and count == 0:
-            info.size = int(wordarr[1])
-            count += 1
-        elif (
-            len(wordarr) > 0
-            and count > 0
-            and wordarr[0][:-1].isdigit()
-            and int(wordarr[0][:-1]) == count - 1
-        ):
-            count += 1
-            rawinfo = wordarr[1].decode("utf-8").split(":")
-            info.blocknames.append(rawinfo[1][0 : rawinfo[1].rfind("_")])
-            info.dnodenames.append(rawinfo[0])
-            stline = line.decode("utf-8")
-            info.machines.append(
-                getIPs(stline[stline.find("DatanodeInfoWithStorage") - 1 :])
-            )
-    assert len(info.blocknames) != 0
-    assert len(info.dnodenames) != 0
-    assert info.size > 0
-    return info
-
-
 if __name__ == "__main__":
     assert len(sys.argv) == 2
     filename = sys.argv[1]
-    info = getinfo(filename)
+    info = FileData(filename)
     print("Size = ", info.size)
     paths = info.paths()
     for i in range(len(paths)):

--- a/compiler/dspash/hdfs_utils.py
+++ b/compiler/dspash/hdfs_utils.py
@@ -1,0 +1,29 @@
+from dspash.hdfs_file_data import FileData
+from typing import List, Tuple
+
+def get_cmd_output(cmd:str):
+    ret = subprocess.check_output(cmd, shell=True, universal_newlines=True, stderr=subprocess.PIPE)
+    return ret.strip()
+
+def _remove_prefix(s:str, prefix:str) -> str:
+    if s.startswith(prefix):
+        return s[len(prefix):]
+    return s
+
+def get_datanode_dir() -> str:
+    data_dir = get_cmd_output("hdfs getconf -confKey dfs.datanode.data.dir")
+    data_dir = _remove_prefix(data_dir, "file://")
+    return data_dir
+
+def get_file_data(filename: str) -> FileData:
+    return FileData(filename)
+
+def get_file_blocks(filename: str) -> List[Tuple[str, List[str]]]:
+    """
+    Returns ordered list of (block_path, [host machines])
+    """
+    filedata = get_file_data(filename)
+    file_blocks = []
+    for i, block in enumerate(filedata.paths()):
+        file_blocks.append((block, filedata.machines[i]))
+    return file_blocks

--- a/compiler/dspash/hdfs_utils.py
+++ b/compiler/dspash/hdfs_utils.py
@@ -1,4 +1,4 @@
-from dspash.hdfs_file_data import FileData
+from dspash.hdfs_file_data import get_hdfs_file_data, FileData
 from typing import List, Tuple
 
 def get_cmd_output(cmd:str):
@@ -16,7 +16,7 @@ def get_datanode_dir() -> str:
     return data_dir
 
 def get_file_data(filename: str) -> FileData:
-    return FileData(filename)
+    return get_hdfs_file_data(filename)
 
 def get_file_blocks(filename: str) -> List[Tuple[str, List[str]]]:
     """

--- a/compiler/dspash/ir_helper.py
+++ b/compiler/dspash/ir_helper.py
@@ -187,7 +187,8 @@ def assign_workers_to_subgraphs(subgraphs:List[IR], file_id_gen: FileIdGen, inpu
 
     # Replace output edges and corrosponding input edges with remote read/write
     for subgraph in subgraphs:
-        worker = get_worker()
+        subgraph_critical_fids = list(filter(lambda fid: fid.has_remote_file_resource(), subgraph.all_fids()))
+        worker = get_worker(subgraph_critical_fids)
         worker._running_processes += 1
         worker_subgraph_pairs.append((worker, subgraph))
         sink_nodes = subgraph.sink_nodes()

--- a/compiler/dspash/worker.sh
+++ b/compiler/dspash/worker.sh
@@ -9,6 +9,13 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 export PYTHONPATH=${PASH_TOP}/python_pkgs/
 export PASH_TIMESTAMP="$(date +"%y-%m-%d-%T")"
 
+# add hdfs directory if hdfs command exist
+if command -v "hdfs" &> /dev/null
+then
+    datanode_dir=$(hdfs getconf -confKey dfs.datanode.data.dir) 
+    export HDFS_DATANODE_DIR=${datanode_dir#"file://"} # removes file:// prefix
+fi
+
 source "$PASH_TOP/compiler/pash_init_setup.sh" $@ --distributed_exec
 
 export PASH_TMP_PREFIX="$(mktemp -d /tmp/pash_XXXXXXX)/"

--- a/compiler/dspash/worker_manager.py
+++ b/compiler/dspash/worker_manager.py
@@ -83,10 +83,17 @@ class WorkersManager():
         # Required to create a correct multi sink graph
         self.args.termination = "" 
 
-    def get_worker(self) -> WorkerConnection:
+    def get_worker(self, fids = None) -> WorkerConnection:
+        if not fids:
+            fids = []
+
         best_worker = None  # Online worker with least work
         for worker in self.workers:
             if not worker.is_online():
+                continue
+            
+            # Skip if any provided fid isn't available on the worker machine
+            if any(map(lambda fid: not fid.is_available_on(worker.host()), fids)):
                 continue
 
             if best_worker is None or best_worker.get_running_processes() > worker.get_running_processes():

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -6,6 +6,7 @@ from definitions.ir.aggregator_node import *
 from definitions.ir.file_id import *
 from definitions.ir.resource import *
 from definitions.ir.nodes.cat import *
+from definitions.ir.nodes.hdfs_cat import HDFSCat
 
 import definitions.ir.nodes.pash_split as pash_split
 import definitions.ir.nodes.r_merge as r_merge
@@ -137,6 +138,14 @@ def compile_command_to_DFG(fileIdGen, command, options,
                        com_options=dfg_options,
                        com_redirs=com_redirs,
                        com_assignments=com_assignments)
+    elif(str(com_name) == "hdfs" and str(dfg_options[0][1]) == "dfs" and str(dfg_options[1][1]) == "-cat"):
+        dfg_node = HDFSCat(dfg_inputs,
+                        dfg_outputs,
+                        com_name,
+                        com_category,
+                        com_options=dfg_options,
+                        com_redirs=com_redirs,
+                        com_assignments=com_assignments)
     else:
         ## Assume: Everything must be completely expanded
         ## TODO: Add an assertion about that.


### PR DESCRIPTION
Extends the distributed execution mode to handle HDFS cat commands. The PR contributes changes on two levels: 
Compiler: 
- To handle HDFS I introduced a new a`RemoteFileResource` interface and `HDFSResource` implements this interface. The hdfs file resource contains information about a block and all the machines the block exists on.
- HDFSCat DFGNode is added. This node is then removed in the graph optimizing step and replaced by Cat nodes where each cat fid has an HDFSResource that corresponds to a block of the HDFS file.

Distributed Execution:  The worker manager policy now takes into account data availability when choosing a worker.