### PR TITLE
Auto-build docker images on new releases and push to dockerhub

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,37 @@
+name: ci
+on:
+  release:
+    types: [published]
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Building debian-10
+        run: |
+            cd scripts/docker/debian
+            docker build -t binpash/pash:debian-10 .
+            docker push binpash/pash:debian-10
+
+      - name: Building ubuntu-18.04
+        run: |
+            cd scripts/docker/ubuntu
+            docker build -t binpash/pash:ubuntu-18.04 . 
+            docker push binpash/pash:ubuntu-18.04
+            docker tag binpash/pash:ubuntu-18.04 binpash/pash:latest
+            docker push binpash/pash:latest
+
+      - name: Building fedora:35
+        run: |
+            cd scripts/docker/fedora
+            docker build -t binpash/pash:fedora-35 .
+            docker push binpash/pash:fedora-35


### PR DESCRIPTION
* Build Ubuntu-18.04, debian:10 and fedora:35 on each new package release.
* The images are built and pushed automatically on dockerhub (can be expanded to other registries as well)

Signed-off-by: Dimitris Karnikis <dkarnikis@gmail.com>