### PR TITLE
Fix the eager runtime intermediate filenames

### DIFF
--- a/compiler/definitions/ir/resource.py
+++ b/compiler/definitions/ir/resource.py
@@ -53,7 +53,11 @@ class FileResource(Resource):
             return self.uri == other.uri
         return False
 
+class TemporaryFileResource(Resource):
+    def __init__(self):
+        self.uri = None
 
+# A FIFO.
 class EphemeralResource(Resource):
     def __init__(self):
         self.uri = None

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -44,9 +44,13 @@ class FileIdGen:
         self.next += 1
         return fileId
 
+    def next_temporary_file_id(self):
+        fileId = self.next_file_id()
+        fileId.make_temporary_file()
+        return fileId
+
     def next_ephemeral_file_id(self):
-        fileId = FileId(self.next, self.prefix)
-        self.next += 1
+        fileId = self.next_file_id()
         fileId.make_ephemeral()
         return fileId
 

--- a/compiler/pash_runtime.py
+++ b/compiler/pash_runtime.py
@@ -692,7 +692,7 @@ def add_eager(eager_input_id, graph, fileIdGen, intermediateFileIdGen, use_dgsh_
     else:
         ## TODO: Remove the line below if eager creates its intermediate file
         ##       on its own.
-        intermediate_fid = intermediateFileIdGen.next_ephemeral_file_id()
+        intermediate_fid = intermediateFileIdGen.next_temporary_file_id()
 
         eager_exec_path = '{}/{}'.format(config.PASH_TOP, runtime_config['eager_executable_path'])
 


### PR DESCRIPTION
A previous intermediate filename of the eager runtime is such as `/path/to/tmpdir/prefix_#fifo1`, even though it's a normal file but not a FIFO. This name doesn't make sense, even if it probably has no direct effect on users. So change the filename to indicate that it is a normal file. The fixed filename is such as `/path/to/tmpdir/prefix_1`.