### PR TITLE
Fix field splittings by missing double quotations

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,3 +74,20 @@ jobs:
           run: |
             # check if everything executed without errors
             cd scripts/workflow && bash exit_code.sh
+
+    shellcheck:
+      runs-on: ubuntu-latest
+      if: github.event.pull_request.draft == false
+      steps:
+        - uses: actions/checkout@v3
+
+        - uses: ludeeus/action-shellcheck@master
+          env:
+            # Only check "Double quote to prevent globbing and word splitting."
+            # now, but we should check others in the future.
+            # https://github.com/koalaman/shellcheck/wiki/Sc2086
+            SHELLCHECK_OPTS: -i SC2086
+          with:
+            ignore_paths:
+              compiler/parser/libdash
+              compiler/tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,11 +83,22 @@ jobs:
 
         - uses: ludeeus/action-shellcheck@master
           env:
-            # Only check "Double quote to prevent globbing and word splitting."
-            # now, but we should check others in the future.
-            # https://github.com/koalaman/shellcheck/wiki/Sc2086
-            SHELLCHECK_OPTS: -i SC2086
+            # Only check some field splitting problems now, but we should check
+            # others in the future.
+            SHELLCHECK_OPTS:
+              -i SC2046
+              -i SC2048
+              -i SC2053
+              -i SC2068
+              -i SC2086
+              -i SC2206
+              -i SC2254
           with:
             ignore_paths:
+              annotations
               compiler/parser/libdash
               compiler/tests
+              evaluation
+              python_pkgs
+              runtime/agg/cpp/tests
+              scripts

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -97,6 +97,7 @@ jobs:
             ignore_paths:
               annotations
               compiler/parser/libdash
+              compiler/test_evaluation_scripts.sh
               compiler/tests
               evaluation
               python_pkgs

--- a/compiler/dspash/worker.sh
+++ b/compiler/dspash/worker.sh
@@ -16,18 +16,18 @@ then
     export HDFS_DATANODE_DIR=${datanode_dir#"file://"} # removes file:// prefix
 fi
 
-source "$PASH_TOP/compiler/pash_init_setup.sh" $@ --distributed_exec
+source "$PASH_TOP/compiler/pash_init_setup.sh" "$@" --distributed_exec
 
 export PASH_TMP_PREFIX="$(mktemp -d /tmp/pash_XXXXXXX)/"
 
 function cleanup() {
-        kill $FILEREADER_PID $DISCOVERY_PID
-        wait $FILEREADER_PID $DISCOVERY_PID 2>/dev/null
-        rm -rf $PASH_TMP_PREFIX
+        kill "$FILEREADER_PID" "$DISCOVERY_PID"
+        wait "$FILEREADER_PID" "$DISCOVERY_PID" 2>/dev/null
+        rm -rf "$PASH_TMP_PREFIX"
 }
 
-$PASH_TOP/runtime/dspash/file_reader/filereader_server &
+"$PASH_TOP/runtime/dspash/file_reader/filereader_server" &
 FILEREADER_PID=$!
-$PASH_TOP/runtime/dspash/file_reader/discovery_server &
+"$PASH_TOP/runtime/dspash/file_reader/discovery_server" &
 DISCOVERY_PID=$!
-python3 "$PASH_TOP/compiler/dspash/worker.py" $@
+python3 "$PASH_TOP/compiler/dspash/worker.py" "$@"

--- a/compiler/execute_gnu_parallel_script.sh
+++ b/compiler/execute_gnu_parallel_script.sh
@@ -32,21 +32,21 @@ seq_output="${intermediary_directory}/${microbenchmark}_seq_output"
 gnu_parallel_output="${intermediary_directory}/${microbenchmark}_gnu_parallel_output"
 
 echo "Environment:"
-cat $env_file
-. $env_file
-export $(cut -d= -f1 $env_file)
+cat "$env_file"
+. "$env_file"
+export "$(cut -d= -f1 "$env_file")"
 
 ## Export necessary functions
-if [ -f $funs_file ]; then
-    source $funs_file
+if [ -f "$funs_file" ]; then
+    source "$funs_file"
 fi
 
 gnu_parallel_result_filename="${results}${experiment}_gnu_parallel.time"
 
 echo "GNU Parallel:"
-cat $gnu_parallel_script
-{ time /bin/bash $gnu_parallel_script > $gnu_parallel_output ; } 2> >(tee "${gnu_parallel_result_filename}" >&2)
+cat "$gnu_parallel_script"
+{ time /bin/bash "$gnu_parallel_script" > "$gnu_parallel_output" ; } 2> >(tee "$gnu_parallel_result_filename" >&2)
 
 echo "Checking for equivalence..."
-diff -s $seq_output $gnu_parallel_output | tee -a "${gnu_parallel_result_filename}"
+diff -s "$seq_output" "$gnu_parallel_output" | tee -a "$gnu_parallel_result_filename"
 

--- a/compiler/parser/run_parser_on_scripts.sh
+++ b/compiler/parser/run_parser_on_scripts.sh
@@ -6,5 +6,5 @@ for script in "$SCRIPTS_DIR"*.sh
 do
     echo "Parsing $script..."
     output=${script/"scripts"/"scripts/json"}.json
-    ./parse_to_json.native $script > "$output"
+    ./parse_to_json.native "$script" > "$output"
 done

--- a/compiler/pash_init_setup.sh
+++ b/compiler/pash_init_setup.sh
@@ -24,7 +24,7 @@ export pash_daemon_communicates_through_unix_pipes_flag=0
 export show_version=0
 export distributed_exec=0
 
-for item in $@
+for item in "$@"
 do
     if [ "$pash_checking_speculation" -eq 1 ]; then
         export pash_checking_speculation=0
@@ -196,7 +196,7 @@ else
 
     pash_communicate_daemon_just_send()
     {
-        pash_communicate_daemon $1
+        pash_communicate_daemon "$1"
     }
 
     pash_wait_until_daemon_listening()

--- a/compiler/pash_init_setup.sh
+++ b/compiler/pash_init_setup.sh
@@ -120,39 +120,39 @@ if [ "$PASH_DEBUG_LEVEL" -eq 0 ]; then
 
     pash_redir_all_output_always_execute()
     {
-        > /dev/null 2>&1 $@
+        > /dev/null 2>&1 "$@"
     }
 
 else
     if [ "$PASH_REDIR" == '&2' ]; then
         pash_redir_output()
         {
-            >&2 $@
+            >&2 "$@"
         }
 
         pash_redir_all_output()
         {
-            >&2 $@
+            >&2 "$@"
         }
 
         pash_redir_all_output_always_execute()
         {
-            >&2 $@
+            >&2 "$@"
         }
     else
         pash_redir_output()
         {
-            >>"$PASH_REDIR" $@
+            >>"$PASH_REDIR" "$@"
         }
 
         pash_redir_all_output()
         {
-            >>"$PASH_REDIR" 2>&1 $@
+            >>"$PASH_REDIR" 2>&1 "$@"
         }
 
         pash_redir_all_output_always_execute()
         {
-            >>"$PASH_REDIR" 2>&1 $@
+            >>"$PASH_REDIR" 2>&1 "$@"
         }
     fi
 fi

--- a/compiler/pash_ptempfile_name.sh
+++ b/compiler/pash_ptempfile_name.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 distro=${1??Distro not given}
-# echo ${PASH_TMP_PREFIX}/pash_$RANDOM$RANDOM$RANDOM
-mktemp -u ${PASH_TMP_PREFIX}/pash_XXXXXXXXXX
+# echo "$PASH_TMP_PREFIX/pash_$RANDOM$RANDOM$RANDOM"
+mktemp -u "$PASH_TMP_PREFIX/pash_XXXXXXXXXX"

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -140,10 +140,10 @@ else
         fi
         
         # Get assigned process id
-        response_args=($daemon_response)
+        response_args=("$daemon_response")
         process_id=${response_args[1]}
     else
-        pash_redir_all_output_always_execute python3 -S "$RUNTIME_DIR//pash_runtime.py" --var_file "${pash_runtime_shell_variables_file}" "${pash_compiled_script_file}" "${pash_input_ir_file}" $@
+        pash_redir_all_output_always_execute python3 -S "$RUNTIME_DIR//pash_runtime.py" --var_file "${pash_runtime_shell_variables_file}" "${pash_compiled_script_file}" "${pash_input_ir_file}" "$@"
         pash_runtime_return_code=$?
     fi
 

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -283,7 +283,12 @@ else
         ## TODO: This might not be necessary
         ## Recover the input arguments of the previous script
         ## Note: We don't need to care about wrap_vars arguments because we have stored all of them already.
-        set -- "$pash_input_args"
+        #
+        # This variable stores arguments as a space-separated stirng, so we
+        # need to unquote it and to split it into multiple strings by shell's
+        # field splitting.
+        # shellcheck disable=SC2086
+        set -- $pash_input_args
         pash_redir_output echo "$$: (5) Reverted to BaSh input arguments: $@"
 
         ## TODO: We probably need to exit with the exit code here or something!

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -156,7 +156,7 @@ else
     # store functions for distributed execution
     if [ "$distributed_exec" -eq 1 ]; then
         declared_functions="${PASH_TMP_PREFIX}/pash_$RANDOM$RANDOM$RANDOM"
-        declare -f > $declared_functions
+        declare -f > "$declared_functions"
         export declared_functions
     fi
 
@@ -201,7 +201,7 @@ else
         if [ "$pash_profile_driven_flag" -eq 1 ]; then
             parallel_script_time_start=$(date +"%s%N")
         fi
-        source "$RUNTIME_DIR/pash_wrap_vars.sh" ${pash_script_to_execute}
+        source "$RUNTIME_DIR/pash_wrap_vars.sh" "$pash_script_to_execute"
         internal_exec_status=$?
         final_steps
         clean_up
@@ -216,13 +216,13 @@ else
             ##
 
             ## Prepare a file for the output shell variables to be saved in
-            pash_output_var_file="$($RUNTIME_DIR/pash_ptempfile_name.sh $distro)"
+            pash_output_var_file=$("$RUNTIME_DIR/pash_ptempfile_name.sh" "$distro")
             # pash_redir_output echo "$$: Output vars: $pash_output_var_file"
 
             ## Prepare a file for the `set` state of the inner shell to be output
-            pash_output_set_file="$($RUNTIME_DIR/pash_ptempfile_name.sh $distro)"
+            pash_output_set_file=$("$RUNTIME_DIR/pash_ptempfile_name.sh" "$distro")
 
-            source "$RUNTIME_DIR/pash_runtime_shell_to_pash.sh" ${pash_output_var_file} ${pash_output_set_file}
+            source "$RUNTIME_DIR/pash_runtime_shell_to_pash.sh" "$pash_output_var_file" "$pash_output_set_file"
 
             ##
             ## (6)
@@ -254,7 +254,7 @@ else
         ## Needed to clear up any past script time start execution times.        
         parallel_script_time_start=None
         clean_up 
-        source "$RUNTIME_DIR/pash_wrap_vars.sh" ${pash_script_to_execute}
+        source "$RUNTIME_DIR/pash_wrap_vars.sh" "$pash_script_to_execute"
         pash_runtime_final_status=$?
         final_steps
     else 
@@ -280,7 +280,7 @@ else
         ## TODO: This might not be necessary
         ## Recover the input arguments of the previous script
         ## Note: We don't need to care about wrap_vars arguments because we have stored all of them already.
-        set -- $pash_input_args
+        set -- "$pash_input_args"
         pash_redir_output echo "$$: (5) Reverted to BaSh input arguments: $@"
 
         ## TODO: We probably need to exit with the exit code here or something!

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -140,7 +140,10 @@ else
         fi
         
         # Get assigned process id
-        response_args=("$daemon_response")
+        # We need to split the daemon response into elements of an array by
+        # shell's field splitting.
+        # shellcheck disable=SC2206
+        response_args=($daemon_response)
         process_id=${response_args[1]}
     else
         pash_redir_all_output_always_execute python3 -S "$RUNTIME_DIR//pash_runtime.py" --var_file "${pash_runtime_shell_variables_file}" "${pash_compiled_script_file}" "${pash_input_ir_file}" "$@"

--- a/compiler/pash_runtime_complete_execution.sh
+++ b/compiler/pash_runtime_complete_execution.sh
@@ -21,14 +21,14 @@ fi
 ## Source back the output variables of the compiled script. 
 ## In all cases we should have executed a script
 pash_redir_output echo "$$: (7) Recovering BaSh variables from: $pash_output_var_file"
-source "$RUNTIME_DIR/pash_source_declare_vars.sh" $pash_output_var_file
+source "$RUNTIME_DIR/pash_source_declare_vars.sh" "$pash_output_var_file"
 
 ## Save the previous `set` state to a variable
 pash_redir_output echo "$$: (7) Reading current BaSh set state from: ${pash_output_set_file}"
 
-pash_redir_output echo "$$: (7) Current BaSh set state: $(cat $pash_output_set_file)"
+pash_redir_output echo "$$: (7) Current BaSh set state: $(cat "$pash_output_set_file")"
 ## WARNING: This has to happen after sourcing the variables so that it overwrites it
-pash_previous_set_status="$(cat $pash_output_set_file)"
+pash_previous_set_status=$(cat "$pash_output_set_file")
 
 export pash_input_args
 pash_redir_output echo "$$: (7) Arguments (might) have been updated to be: $pash_input_args"
@@ -36,7 +36,7 @@ pash_redir_output echo "$$: (7) Arguments (might) have been updated to be: $pash
 ## Propagate the `set` state after running the script to the outer script
 ## TODO: Maybe move this to the end to avoid spurious failures
 pash_redir_output echo "$$: (7) Current PaSh set state: $-"
-source "$RUNTIME_DIR/pash_set_from_to.sh" "$-" "$(cat $pash_output_set_file)"
+source "$RUNTIME_DIR/pash_set_from_to.sh" "$-" "$(cat "$pash_output_set_file")"
 pash_redir_output echo "$$: (7) Reverted to BaSh set state before exiting: $-"
 
 pash_redir_output echo "$$: (7) Reverting last BaSh exit code: $pash_runtime_final_status"

--- a/compiler/pash_runtime_shell_to_pash.sh
+++ b/compiler/pash_runtime_shell_to_pash.sh
@@ -24,6 +24,6 @@ pash_redir_output echo "$$: (5) Reverted to PaSh set state to: $-"
 
 
 ## Save the current variables
-source "$RUNTIME_DIR/pash_declare_vars.sh" $output_vars_file
+source "$RUNTIME_DIR/pash_declare_vars.sh" "$output_vars_file"
 # pash_redir_output echo "$$: (5) Exiting from BaSh with BaSh status: $pash_exec_status"
 # (exit "$pash_exec_status")

--- a/compiler/pash_set_from_to.sh
+++ b/compiler/pash_set_from_to.sh
@@ -6,7 +6,7 @@ to_set=${2?To set not given}
 ## Finds the difference of set variables (removing the c, s one since it cannot be actually set and unset)
 pash_redir_output echo "From set: $from_set"
 pash_redir_output echo "To set: $to_set"
-IFS=',' read -r pash_set_to_remove pash_set_to_add <<< "$($RUNTIME_LIBRARY_DIR/set-diff $from_set $to_set)"
+IFS=',' read -r pash_set_to_remove pash_set_to_add <<<"$("$RUNTIME_LIBRARY_DIR/set-diff" "$from_set" "$to_set")"
 pash_redir_output echo "To add: $pash_set_to_add"
 pash_redir_output echo "To remove: $pash_set_to_remove"
 pash_redir_all_output_always_execute set "-$pash_set_to_add"

--- a/compiler/pash_source_declare_vars.sh
+++ b/compiler/pash_source_declare_vars.sh
@@ -11,16 +11,16 @@
 
 filter_vars_file()
 {
-    cat $1 | grep -v "^declare -\([A-Za-z]\|-\)* \(pash\|BASH\|LINENO\|EUID\|GROUPS\)"    
+    cat "$1" | grep -v "^declare -\([A-Za-z]\|-\)* \(pash\|BASH\|LINENO\|EUID\|GROUPS\)"
 }
 
 ## TODO: Error handling if the argument is empty?
 if [ "$PASH_DEBUG_LEVEL" -eq 0 ]; then
-        > /dev/null 2>&1 $@
+        > /dev/null 2>&1 "$@"
 else
     if [ "$PASH_REDIR" == '&2' ]; then
-        >&2 source <(filter_vars_file $1)
+        >&2 source <(filter_vars_file "$1")
     else
-        >>"$PASH_REDIR" 2>&1 source <(filter_vars_file $1)
+        >>"$PASH_REDIR" 2>&1 source <(filter_vars_file "$1")
     fi
 fi

--- a/compiler/pash_wrap_vars.sh
+++ b/compiler/pash_wrap_vars.sh
@@ -17,8 +17,8 @@ pash_redir_output echo "$$: (3) Reverted to BaSh set state: $-"
 ## Recover the input arguments of the previous script
 ## Note: We don't need to care about wrap_vars arguments because we have stored all of them already.
 #
-# This variable stores arguments as space-separated multiple strings, so we should unquote it to
-# treat it as an array of strings but not just one string.
+# This variable stores arguments as a space-separated stirng, so we need to
+# unquote it and to split it into multiple strings by shell's field splitting.
 # shellcheck disable=SC2086
 set -- $pash_input_args
 pash_redir_output echo "$$: (3) Reverted to BaSh input arguments: $@"

--- a/compiler/pash_wrap_vars.sh
+++ b/compiler/pash_wrap_vars.sh
@@ -16,6 +16,10 @@ pash_redir_output echo "$$: (3) Reverted to BaSh set state: $-"
 
 ## Recover the input arguments of the previous script
 ## Note: We don't need to care about wrap_vars arguments because we have stored all of them already.
+#
+# This variable stores arguments as space-separated multiple strings, so we should unquote it to
+# treat it as an array of strings but not just one string.
+# shellcheck disable=SC2086
 set -- $pash_input_args
 pash_redir_output echo "$$: (3) Reverted to BaSh input arguments: $@"
 
@@ -32,7 +36,7 @@ then
     internal_exec_status=$?
     ## Make sure that any input argument changes are propagated outside
     export pash_input_args="$@"
-    (exit $internal_exec_status)
+    (exit "$internal_exec_status")
 }
 else 
 {
@@ -40,6 +44,6 @@ else
     internal_exec_status=$?
     ## Make sure that any input argument changes are propagated outside
     export pash_input_args="$@"
-    (exit $internal_exec_status)
+    (exit "$internal_exec_status")
 }
 fi

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -101,11 +101,11 @@ pipeline_microbenchmarks=(
 execute_pash_and_check_diff() {
     TIMEFORMAT="%3R" # %3U %3S"
     if [ "$DEBUG" -eq 1 ]; then
-        { time "$PASH_TOP/pa.sh" $@ ; } 1> "$pash_output" 2> >(tee -a "${pash_time}" >&2) &&
+        { time "$PASH_TOP/pa.sh" "$@" ; } 1> "$pash_output" 2> >(tee -a "${pash_time}" >&2) &&
         diff -s "$seq_output" "$pash_output" | head | tee -a "${pash_time}" >&2
     else
 
-        { time "$PASH_TOP/pa.sh" $@ ; } 1> "$pash_output" 2>> "${pash_time}" &&
+        { time "$PASH_TOP/pa.sh" "$@" ; } 1> "$pash_output" 2>> "${pash_time}" &&
         b=$(cat "$pash_time"); 
         test_diff_ec=$(cmp -s "$seq_output" "$pash_output" && echo 0 || echo 1)
         # differ

--- a/compiler/test_evaluation_scripts.sh
+++ b/compiler/test_evaluation_scripts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # time: print real in seconds, to simplify parsing
 ## Necessary to set PASH_TOP
-cd $(dirname $0)
+cd "$(dirname "$0")"
 export PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}
 export DEBUG=0
 export PASH_LOG=1
@@ -9,7 +9,7 @@ export PASH_LOG=1
 ## Determines whether the experimental pash flags will be tested. 
 ## By default they are not.
 export EXPERIMENTAL=0
-for item in $@
+for item in "$@"
 do
     if [ "--debug" == "$item" ] || [ "-d" == "$item" ]; then
         export DEBUG=1
@@ -32,7 +32,7 @@ results_time_pash=${results_time}_pash
 echo "Deleting eager intermediate files..."
 rm -rf "$test_results_dir"
 rm -rf "$intermediary_dir"
-mkdir -p $intermediary_dir
+mkdir -p "$intermediary_dir"
 mkdir -p "$test_results_dir"
 
 echo "Generating inputs..."
@@ -109,14 +109,14 @@ execute_pash_and_check_diff() {
         b=$(cat "$pash_time"); 
         test_diff_ec=$(cmp -s "$seq_output" "$pash_output" && echo 0 || echo 1)
         # differ
-        script=$(basename $script_to_execute)
-        if [ $test_diff_ec -ne 0 ]; then
+        script=$(basename "$script_to_execute")
+        if [ "$test_diff_ec" -ne 0 ]; then
             c=$(diff -s "$seq_output" "$pash_output" | head)
             echo "$c$b" > "${pash_time}"
-            echo "$script are not identical" >> $test_results_dir/result_status
+            echo "$script are not identical" >> "$test_results_dir/result_status"
         else
             echo "Files $seq_output and $pash_output are identical" > "${pash_time}"
-            echo "$script are identical" >> $test_results_dir/result_status
+            echo "$script are identical" >> "$test_results_dir/result_status"
         fi
 
     fi
@@ -150,10 +150,10 @@ execute_tests() {
         input_file="${prefix}_test.in"
 
         if [ -f "$env_file" ]; then
-            . $env_file
-            vars_to_export=$(cut -d= -f1 $env_file)
+            . "$env_file"
+            vars_to_export=$(cut -d= -f1 "$env_file")
             if [ ! -z "$vars_to_export" ]; then
-                export $vars_to_export
+                export "$vars_to_export"
             fi
         else
             echo "|-- Does not have env file"
@@ -161,7 +161,7 @@ execute_tests() {
 
         ## Export necessary functions
         if [ -f "$funs_file" ]; then
-            source $funs_file
+            source "$funs_file"
         fi
 
         ## Redirect the input if there is an input file
@@ -173,20 +173,19 @@ execute_tests() {
 
         TIMEFORMAT="${microbenchmark%%.*}:%3R" # %3U %3S"
         echo -n "|-- Executing the script with bash..."
-        { time /bin/bash "$script_to_execute" > $seq_output ; } \
+        { time /bin/bash "$script_to_execute" > "$seq_output" ; } \
             < "$stdin_redir" 2>> "${seq_time}"
         echo "   exited with $?"
-        tail -n1 ${seq_time} >> ${results_time_bash}
+        tail -n1 "$seq_time" >> "$results_time_bash"
         for conf in "${configurations[@]}"; do
             for n_in in "${n_inputs[@]}"; do
                 echo "|-- Executing with pash --width ${n_in} ${conf}..."
-                export pash_time="${test_results_dir}/${microbenchmark}_${n_in}_distr_$(echo ${conf} | tr -d ' ').time"
+                export pash_time="${test_results_dir}/${microbenchmark}_${n_in}_distr_$(echo "$conf" | tr -d ' ').time"
                 export pash_output="${intermediary_dir}/${microbenchmark}_${n_in}_pash_output"
                 export script_conf=${microbenchmark}_${n_in}
                 echo '' > "${pash_time}"
                 # do we need to write the PaSh output ?
-                cat $stdin_redir |
-                    execute_pash_and_check_diff -d $PASH_LOG $assert_correctness ${conf} --width "${n_in}" --output_time $script_to_execute                 
+                execute_pash_and_check_diff -d "$PASH_LOG" "$assert_correctness" "$conf" --width "$n_in" --output_time "$script_to_execute" <"$stdin_redir"
                 tail -n1 "${pash_time}" >> "${results_time_pash}_${n_in}"
             done
         done
@@ -212,15 +211,15 @@ case "$distro" in
     freebsd*)  
         # change sed to gsed
         sed () {
-            gsed $@
+            gsed "$@"
         }
         ;;
     *)
         ;;
 esac
 
-echo "group,Bash,Pash2,Pash8" > ${results_time}
-paste -d'@' $test_results_dir/results.time_*  | sed 's\,\.\g' | sed 's\:\,\g' | sed 's\@\,\g' >> ${results_time}
+echo "group,Bash,Pash2,Pash8" > "$results_time"
+paste -d'@' "$test_results_dir"/results.time_*  | sed 's\,\.\g' | sed 's\:\,\g' | sed 's\@\,\g' >> "$results_time"
 
 #echo "Below follow the identical outputs:"
 #grep "are identical" "$test_results_dir"/result_status | awk '{print $1}'

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -279,6 +279,12 @@ test_expand_u_positional()
     $shell expand-u-positional.sh
 }
 
+test_quoting()
+{
+    local shell=$1
+    echo "ababa" | $shell -c 'tr -dc abc'
+}
+
 ## We run all tests composed with && to exit on the first that fails
 if [ "$#" -eq 0 ]; then
     run_test test1
@@ -316,6 +322,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_umask
     run_test test_expand_u
     run_test test_expand_u_positional
+    run_test test_quoting
 else
     for testname in $@
     do

--- a/pa.sh
+++ b/pa.sh
@@ -12,7 +12,7 @@ function kill_all() {
     # kill all my subprocesses only
     kill -s SIGKILL 0
     # kill pash_daemon
-    kill -s SIGKILL $daemon_pid
+    kill -s SIGKILL "$daemon_pid"
 }
 ## Save the umask to first create some files and then revert it
 old_umask=$(umask)
@@ -21,7 +21,7 @@ old_umask=$(umask)
 umask u=rwx,g=rx,o=rx
 
 if [ "$#" -eq 1 ] && [ "$1" = "--init" ]; then
-  $PASH_TOP/compiler/superoptimize.sh
+  "$PASH_TOP"/compiler/superoptimize.sh
   exit
 fi
 

--- a/pa.sh
+++ b/pa.sh
@@ -53,7 +53,7 @@ source "$PASH_TOP/compiler/pash_init_setup.sh" "$@"
 
 if [ "$pash_daemon" -eq 1 ] && [ "$show_version" -eq 0 ]; then
   ## TODO: If possible, move the daemon start as easly as possible to reduce waiting
-  python3 -S "$PASH_TOP/compiler/pash_runtime_daemon.py" $@ &
+  python3 -S "$PASH_TOP/compiler/pash_runtime_daemon.py" "$@" &
   daemon_pid=$!
   ## Wait until daemon has established connection
   ##
@@ -62,12 +62,12 @@ if [ "$pash_daemon" -eq 1 ] && [ "$show_version" -eq 0 ]; then
 fi
 
 ## Restore the umask before executing
-umask ${old_umask}
-PASH_FROM_SH="pa.sh" python3 -S $PASH_TOP/compiler/pash.py "$@"
+umask "$old_umask"
+PASH_FROM_SH="pa.sh" python3 -S "$PASH_TOP/compiler/pash.py" "$@"
 pash_exit_code=$?
 if [ "$pash_daemon" -eq 1 ] && [ "$show_version" -eq 0 ]; then
   ## Only wait for daemon if it lives (it might be dead, rip)
-  if ps -p $daemon_pid > /dev/null 
+  if ps -p "$daemon_pid" > /dev/null
   then
     ## Send and receive from daemon
     msg="Done"
@@ -87,4 +87,4 @@ if [ "$PASH_DEBUG_LEVEL" -eq 0 ]; then
   rm -rf "${PASH_TMP_PREFIX}"
 fi
 
-(exit $pash_exit_code)
+(exit "$pash_exit_code")

--- a/runtime/agg/opt/add.sh
+++ b/runtime/agg/opt/add.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-paste -d+ $* | bc
+paste -d+ "$@" | bc

--- a/runtime/agg/opt/concat.sh
+++ b/runtime/agg/opt/concat.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-cat $*
+cat "$@"

--- a/runtime/agg/opt/count.sh
+++ b/runtime/agg/opt/count.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-awk '{ count[$2] += $1 } END { for(e in count) print count[e], e }' $*
+awk '{ count[$2] += $1 } END { for(e in count) print count[e], e }' "$@"

--- a/runtime/agg/opt/uniq-c.2.sh
+++ b/runtime/agg/opt/uniq-c.2.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-END_OF_1=$(tail -n 1 $1)
-END_NUM=$(echo $END_OF_1 | grep -E -o '^[ ]*[0-9]*[ ]*' | tr -d "[:space:]")
-END_WORD=$(echo $END_OF_1 | sed 's/^[ ]*[0-9]*[ ]*//g')
+END_OF_1=$(tail -n 1 "$1")
+END_NUM=$(echo "$END_OF_1" | grep -E -o '^[ ]*[0-9]*[ ]*' | tr -d "[:space:]")
+END_WORD=$(echo "$END_OF_1" | sed 's/^[ ]*[0-9]*[ ]*//g')
 
-START_OF_2=$(head -n 1 $2)
-START_NUM=$(echo $START_OF_2 | grep -E -o '^[ ]*[0-9]*[ ]*' | tr -d "[:space:]")
-START_WORD=$(echo $START_OF_2 | sed 's/^[ ]*[0-9]*[ ]*//g')
+START_OF_2=$(head -n 1 "$2")
+START_NUM=$(echo "$START_OF_2" | grep -E -o '^[ ]*[0-9]*[ ]*' | tr -d "[:space:]")
+START_WORD=$(echo "$START_OF_2" | sed 's/^[ ]*[0-9]*[ ]*//g')
 
-if [[ $START_WORD == $END_WORD ]]; then
+if [[ $START_WORD == "$END_WORD" ]]; then
   TOTAL_NUM=$((START_NUM + END_NUM))
-  sed '$d' $1
-  printf "%7s %s\n" $TOTAL_NUM $START_WORD
-  sed '1d' $2
+  sed '$d' "$1"
+  printf "%7s %s\n" "$TOTAL_NUM" "$START_WORD"
+  sed '1d' "$2"
 else
-  cat $1 $2
+  cat "$1" "$2"
 fi

--- a/runtime/agg/opt/uniq.sh
+++ b/runtime/agg/opt/uniq.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # simply rerun uniq
-cat $* | uniq
+cat "$@" | uniq

--- a/runtime/agg/opt/wc.2.sh
+++ b/runtime/agg/opt/wc.2.sh
@@ -4,11 +4,11 @@
 # FIXME needs correct padding
 
 paste -d '+'
-    <(cat $1 |
+    <(cat "$1" |
       wc |
       tr -s ' '  '\n' |
       tail -n +2)
-    <(cat $2 |
+    <(cat "$2" |
       wc |
       tr -s ' '  '\n' |
       tail -n +2) |

--- a/runtime/agg/opt/wc.sh
+++ b/runtime/agg/opt/wc.sh
@@ -7,4 +7,4 @@ for i in "$@"; do
 done
 A="$A | bc | tr -s '\n'  ' ' | sed 's/^/   /' | sed 's/$/\n /'"
 
-eval $A
+eval "$A"

--- a/runtime/auto-split.sh
+++ b/runtime/auto-split.sh
@@ -2,7 +2,7 @@
 
 input="$1"
 shift
-outputs="$@"
+outputs=("$@")
 n_outputs="$#"
 
 # Set a default DISH_TOP in this directory if it doesn't exist
@@ -11,8 +11,8 @@ PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 temp="$(mktemp -u /tmp/pash_XXXXXXXXXX)"
 
 cat "$input" > "$temp"
-total_lines=$(wc -l $temp | cut -f 1 -d ' ')
-batch_size=$( expr $total_lines / $n_outputs )
+total_lines=$(wc -l "$temp" | cut -f 1 -d ' ')
+batch_size=$((total_lines / n_outputs))
 # echo "Input: $input"
 # echo "Ouputs: $outputs"
 # echo "Number of outputs: $n_outputs"
@@ -21,13 +21,13 @@ batch_size=$( expr $total_lines / $n_outputs )
 
 cleanup()
 {
-    kill -SIGPIPE $split_pid > /dev/null 2>&1
+    kill -SIGPIPE "$split_pid" > /dev/null 2>&1
 }
 trap cleanup EXIT
 
 
 # echo "$PASH_TOP/evaluation/tools/split $input $batch_size $outputs"
-$PASH_TOP/runtime/split "$temp" "$batch_size" $outputs &
+"$PASH_TOP"/runtime/split "$temp" "$batch_size" "${outputs[@]}" &
 split_pid=$!
-wait $split_pid
-rm -f $temp
+wait "$split_pid"
+rm -f "$temp"

--- a/runtime/bigrams_aux_map.sh
+++ b/runtime/bigrams_aux_map.sh
@@ -20,27 +20,27 @@ bigram_aux_map()
     aux1=$(mktemp -u)
     aux2=$(mktemp -u)
 
-    mkfifo $s2
-    mkfifo $aux1
-    mkfifo $aux2
-    cat $IN |
-        tee $s2 $aux1 $aux2 |
+    mkfifo "$s2"
+    mkfifo "$aux1"
+    mkfifo "$aux2"
+    cat "$IN" |
+        tee "$s2" "$aux1" "$aux2" |
         tail +2 |
-        paste $s2 - > $OUT &
+        paste "$s2" - > "$OUT" &
 
     ## The goal of this is to write the first line of $IN in the $AUX_HEAD
     ## stream and the last line of $IN in $AUX_TAIL
 
     ## TODO: I am not sure if using head/tail like this works or breaks
     ## the pipes
-    cat $aux1 | ( head -n 1 > $AUX_HEAD; dd of=/dev/null > /dev/null 2>&1 ) &
-    tail -n 1 $aux2 > $AUX_TAIL &
+    cat "$aux1" | ( head -n 1 > "$AUX_HEAD"; dd of=/dev/null > /dev/null 2>&1 ) &
+    tail -n 1 "$aux2" > "$AUX_TAIL" &
 
     wait
 
-    rm $s2
-    rm $aux1
-    rm $aux2
+    rm "$s2"
+    rm "$aux1"
+    rm "$aux2"
 }
 
 ##
@@ -61,16 +61,16 @@ bigram_aux_reduce()
 
     temp=$(mktemp -u)
 
-    mkfifo $temp
+    mkfifo "$temp"
 
-    cat $AUX_HEAD1 > $AUX_HEAD_OUT &
-    cat $AUX_TAIL2 > $AUX_TAIL_OUT &
-    paste $AUX_TAIL1 $AUX_HEAD2 > $temp &
-    cat $IN1 $temp $IN2 > $OUT &
+    cat "$AUX_HEAD1" > "$AUX_HEAD_OUT" &
+    cat "$AUX_TAIL2" > "$AUX_TAIL_OUT" &
+    paste "$AUX_TAIL1" "$AUX_HEAD2" > "$temp" &
+    cat "$IN1" "$temp" "$IN2" > "$OUT" &
 
     wait
 
-    rm $temp
+    rm "$temp"
 }
 
 ##VTODO: Deplete the aux outputs of the last reduce

--- a/runtime/cat_output_files.sh
+++ b/runtime/cat_output_files.sh
@@ -2,4 +2,4 @@
 
 distr_output_dir=$1
 
-cat $distr_output_dir/*
+cat "$distr_output_dir"/*

--- a/runtime/dgsh_tee.sh
+++ b/runtime/dgsh_tee.sh
@@ -1,7 +1,8 @@
+#!/usr/bin/env bash
 
 input=${1?"ERROR: dgsh-tee: No input file given"}
 output=${2?"ERROR: dgsh-tee: No output file given"}
-args=${@:3}
+args=("${@:3}")
 
 # Set a default DISH_TOP in this directory if it doesn't exist
 PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
@@ -17,4 +18,4 @@ PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 # $PASH_TOP/runtime/dgsh-tee -i "$input" -o "$output" $args &
 # dgsh_tee_pid=$!
 # wait $dgsh_tee_pid
-$PASH_TOP/runtime/dgsh-tee -i "$input" -o "$output" $args
+"$PASH_TOP"/runtime/dgsh-tee -i "$input" -o "$output" "${args[@]}"

--- a/runtime/distributed.sh
+++ b/runtime/distributed.sh
@@ -17,15 +17,15 @@ sleep 5
 #   cat $IN | nc -N WORKER WORKER_DATA_PORT
 
 
-cat fifo5555 fifo5556 > $OUT
+cat fifo5555 fifo5556 > "$OUT"
 nc -l -p 5555 > fifo5555 &
 nc -l -p 5556 > fifo5556 &
 # beta runs: `nc -l 5000 | grep -v "onetwo" | tr '[:lower:]' '[:upper:]' | nc -C 158.130.4.212 5555`
 ./client.js beta 'nc -l 5000 | grep -v "onetwo" | tr "[:lower:]" "[:upper:]" | nc -C 158.130.4.212 5555'
 # gamma runs: `nc -l 5000 | grep -v "onetwo" | tr '[:lower:]' '[:upper:]' | nc -C 158.130.4.212 5555`
 ./client.js gamma 'nc -l 5000 | grep -v "onetwo" | tr "[:lower:]" "[:upper:]" | nc -C 158.130.4.212 5556'
-cat $IN | nc -N beta.ndr.md 5000
-cat $IN | nc -N gamma.ndr.md 5000
+cat "$IN" | nc -N beta.ndr.md 5000
+cat "$IN" | nc -N gamma.ndr.md 5000
 
 
 # Collect results
@@ -41,9 +41,9 @@ nc -l -p 5558 > r4 &
 # -N stops after EOF
 
 # Receiver should run
-nc -l -p 5000 | tr '[:lower:]' '[:upper:]'  | nc $DSTAR 5555
+nc -l -p 5000 | tr '[:lower:]' '[:upper:]'  | nc "$DSTAR" 5555
 
 # Distribute load
-cat ./a/b | tr 'x' 'x' | nc $B 5000
-cat ./a/b | tr 'x' 'x' | nc $C 5000
-cat ./a/b | tr 'x' 'x' | nc $D 5000
+cat ./a/b | tr 'x' 'x' | nc "$B" 5000
+cat ./a/b | tr 'x' 'x' | nc "$C" 5000
+cat ./a/b | tr 'x' 'x' | nc "$D" 5000

--- a/runtime/dspash/dfs_split_reader.sh
+++ b/runtime/dspash/dfs_split_reader.sh
@@ -1,1 +1,1 @@
-$PASH_TOP/runtime/dspash/file_reader/dfs_split_reader --config $@
+"$PASH_TOP/runtime/dspash/file_reader/dfs_split_reader" --config "$@"

--- a/runtime/dspash/remote_read.sh
+++ b/runtime/dspash/remote_read.sh
@@ -1,1 +1,1 @@
-$PASH_TOP/runtime/dspash/file_reader/datastream_client --type read $@
+"$PASH_TOP/runtime/dspash/file_reader/datastream_client" --type read "$@"

--- a/runtime/dspash/remote_write.sh
+++ b/runtime/dspash/remote_write.sh
@@ -1,1 +1,1 @@
-$PASH_TOP/runtime/dspash/file_reader/datastream_client --type write $@
+"$PASH_TOP"/runtime/dspash/file_reader/datastream_client --type write "$@"

--- a/runtime/eager.sh
+++ b/runtime/eager.sh
@@ -17,5 +17,5 @@ PASH_TOP=${PASH_TOP:-$(git rev-parse --show-toplevel)}
 # $PASH_TOP/runtime/eager "$input" "$output" "$intermediate_file" &
 # eager_pid=$!
 # wait $eager_pid
-$PASH_TOP/runtime/eager "$input" "$output" "$intermediate_file"
+"$PASH_TOP"/runtime/eager "$input" "$output" "$intermediate_file"
 rm "$intermediate_file"

--- a/runtime/eager_test.sh
+++ b/runtime/eager_test.sh
@@ -5,7 +5,7 @@ mkfifo s1 s2
 # IN=test_in.txt
 IN=../scripts/input/1G.txt
 
-cat $IN > s1 &
+cat "$IN" > s1 &
 cat s2 > test_out.txt &
 ./eager s1 s2 intermediate &
 

--- a/runtime/merge-uniq.sh
+++ b/runtime/merge-uniq.sh
@@ -6,4 +6,4 @@
 A=${1:-1.txt}
 B=${1:-2.txt}
 C=${1:-3.txt}
-awk '{ count[$2] += $1 } END { for(e in count) print count[e], e }' $A $B $C
+awk '{ count[$2] += $1 } END { for(e in count) print count[e], e }' "$A" "$B" "$C"

--- a/runtime/page-per-line.sh
+++ b/runtime/page-per-line.sh
@@ -4,7 +4,7 @@
 # It also prefixes with the URL
 
 page_per_line () {
-  curl -s $1 | tr -d "\n\r" | tr -d '\n' | sed "s/^/$0 /" | sed -e '/.$/a\'
+  curl -s "$1" | tr -d "\n\r" | tr -d '\n' | sed "s/^/$0 /" | sed -e '/.$/a\'
 }
 
 export -f page_per_line

--- a/runtime/redirect_stdin_to.sh
+++ b/runtime/redirect_stdin_to.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 ## TODO: Is this a hack?
-{ cat > ${1?No file to redirect to} <&3 3<&- & } 3<&0
+{ cat > "${1?No file to redirect to}" <&3 3<&- & } 3<&0

--- a/runtime/split_pipe.sh
+++ b/runtime/split_pipe.sh
@@ -1,11 +1,11 @@
-$BATCH_SIZE=$1
-$VIRTUAL_DIR=$2
-$OUTPUT1=$3
-$OUTPUT2=$4
+BATCH_SIZE=$1
+VIRTUAL_DIR=$2
+OUTPUT1=$3
+OUTPUT2=$4
 
 tee >(
-    head -n $BATCH_SIZE > "${VIRTUAL_DIR}/${OUTPUT1}";
-    $PASH_TOP/evaluation/tools/drain_stream.sh &
+    head -n "$BATCH_SIZE" > "${VIRTUAL_DIR}/${OUTPUT1}";
+    "$PASH_TOP"/evaluation/tools/drain_stream.sh &
     cat "${VIRTUAL_DIR}/${OUTPUT1}" > "${OUTPUT1}") |
     ( tail -n $((BATCH_SIZE+1)) > "${OUTPUT2}";
-      $PASH_TOP/evaluation/tools/drain_stream.sh)
+      "$PASH_TOP"/evaluation/tools/drain_stream.sh)

--- a/runtime/wait_for_output_and_sigpipe_rest.sh
+++ b/runtime/wait_for_output_and_sigpipe_rest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## TODO: Give it the output pid as an argument
-wait $@
+wait "$@"
 
 ## TODO: This only works if there is only a single output node 
 ##         (and a single node given as an argument to `wait`).
@@ -12,8 +12,9 @@ export internal_exec_status=$?
 # Note: We need the || true after the grep so that it doesn't exit with error if it finds nothing.
 
 
-
-
+# This value may contains multiple pids as a whitespace-separated string, and
+# we must split it as multiple pids by shell's field splitting.
+# shellcheck disable=SC2086
 (> /dev/null 2>&1 kill -SIGPIPE $pids_to_kill || true)
 
 ##

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 # check the git status of the project
 if git rev-parse --git-dir > /dev/null 2>&1; then
     # we have cloned from the git repo, so all the .git related files/metadata are available


### PR DESCRIPTION
Expansions with unintentional field splitting by shell maybe cause bugs, so we usually wrap them with double quotes to prevent the bugs.

In practice, PaSH has an inconsistent argument handling bug because the current implementation wraps the potential parameter expansion with double quotes at one place but doesn't at another one. For example, PaSH raises a parsing error when running the command below.

```sh
$ pa.sh -c 'cat foo bar | tr -dc abc'
...
pash_runtime_daemon.py: error: argument -d/--debug: invalid int value: 'c'
...
```

To fix this error and prevent similar potential bugs, wrap expansions with double quotes and test using shellcheck to check missing quotations automatically.