### PR TITLE
Dspash fixes

### DIFF
--- a/compiler/definitions/ir/nodes/dfs_split_reader.py
+++ b/compiler/definitions/ir/nodes/dfs_split_reader.py
@@ -13,13 +13,12 @@ class DFSSplitReader(DFGNode):
     def set_server_address(self, addr): # ex addr: 127.0.0.1:50051
          self.com_options.append((3, Arg(string_to_argument(f"--addr {addr}"))))
 
-def make_dfs_split_reader_node(inputs, output, split_num, prefix):
+def make_dfs_split_reader_node(inputs, output, split_num):
     split_reader_bin = os.path.join(config.PASH_TOP, config.config['runtime']['dfs_split_reader_binary'])
     com_name = Arg(string_to_argument(split_reader_bin))
     com_category = "pure"
     options = []
-    options.append((1, Arg(string_to_argument(f"--prefix '{prefix}'"))))
-    options.append((2, Arg(string_to_argument(f"--split {split_num}"))))
+    options.append((1, Arg(string_to_argument(f"--split {split_num}"))))
 
     return DFSSplitReader(inputs,
                [output],

--- a/compiler/dspash/hdfs_file_data.py
+++ b/compiler/dspash/hdfs_file_data.py
@@ -7,7 +7,8 @@ from typing import List, Tuple
 import requests
 
 HDFSBlock = namedtuple("HDFSBlock", "path hosts")
-
+# The Bash helper function name (defind in hdfs_utils.sh) for getting the local block path
+HDFS_BLOCK_PATH_FUNC = "get_hdfs_block_path" 
 
 class FileData(object):
     def __init__(self, filename):
@@ -28,13 +29,7 @@ class FileData(object):
         for i in range(len(self.blocknames)):
             filepaths.append(
                 os.path.join(
-                    "current",
-                    self.dnodenames[i],
-                    "current",
-                    "finalized",
-                    "subdir0",
-                    "subdir0",
-                    self.blocknames[i],
+                    f"$({HDFS_BLOCK_PATH_FUNC} {self.dnodenames[i]} {self.blocknames[i]})"
                 )
             )
         return filepaths

--- a/compiler/dspash/hdfs_utils.sh
+++ b/compiler/dspash/hdfs_utils.sh
@@ -1,0 +1,12 @@
+# Helper functions and env for hdfs support
+
+datanode_dir=$(hdfs getconf -confKey dfs.datanode.data.dir) 
+export HDFS_DATANODE_DIR=${datanode_dir#"file://"} # removes file:// prefix
+
+function get_hdfs_block_path() {
+    dnodeName="$1"
+    blockID="$2"
+    find "$HDFS_DATANODE_DIR/current/$dnodeName" -name "$blockID"
+}
+
+export -f get_hdfs_block_path

--- a/compiler/dspash/ir_helper.py
+++ b/compiler/dspash/ir_helper.py
@@ -261,8 +261,6 @@ def assign_workers_to_subgraphs(subgraphs:List[IR], file_id_gen: FileIdGen, inpu
         worker._running_processes += 1
         worker_subgraph_pairs.append((worker, subgraph))
         sink_nodes = subgraph.sink_nodes()
-        # print(sink_nodes)
-        # assert(len(sink_nodes) == 1)
         
         for sink_node in sink_nodes:
             for out_edge in subgraph.get_node_output_fids(sink_node):

--- a/compiler/dspash/ir_helper.py
+++ b/compiler/dspash/ir_helper.py
@@ -237,6 +237,10 @@ def assign_workers_to_subgraphs(subgraphs:List[IR], file_id_gen: FileIdGen, inpu
         source_nodes = subgraph.source_nodes()
         for source in source_nodes:
             for in_edge in subgraph.get_node_input_fids(source):
+                # If we didn't expand HDFSCat then we shouldn't modify it's input fids
+                # We might need annotation changes if we need to be more general
+                if isinstance(subgraph.get_node(source), HDFSCat):
+                    continue
                 if in_edge.has_file_resource() or in_edge.has_file_descriptor_resource():
                     # setup
                     stdout = add_stdout_fid(main_graph, file_id_gen)

--- a/compiler/dspash/worker.py
+++ b/compiler/dspash/worker.py
@@ -1,5 +1,5 @@
 import socket
-from threading import Thread
+from multiprocessing import Process
 from socket_utils import encode_request, decode_request
 import subprocess
 import sys
@@ -70,7 +70,7 @@ class Worker:
             while(True):
                 conn, addr = self.s.accept()
                 print(f"got new connection")     
-                t = Thread(target=manage_connection, args=[conn, addr])
+                t = Process(target=manage_connection, args=[conn, addr])
                 t.start()
                 connections.append(t)
         for t in connections:

--- a/compiler/dspash/worker.py
+++ b/compiler/dspash/worker.py
@@ -1,14 +1,9 @@
-import socket, pickle
+import socket
 from threading import Thread
 from socket_utils import encode_request, decode_request
 import subprocess
-import json
 import sys
 import os
-import asyncio
-import shlex
-import time
-import uuid
 import argparse
 
 PASH_TOP = os.environ['PASH_TOP']
@@ -126,7 +121,7 @@ def init():
     config.annotations = load_annotation_files(
         config.config['distr_planner']['annotations_dir'])
     pash_runtime.runtime_config = config.config['distr_planner']
-    pash_runtime.termination = ""
+    config.pash_args.termination = "" # needed because graphs could have multiples sinks
 
 def main():
     init()

--- a/compiler/dspash/worker.sh
+++ b/compiler/dspash/worker.sh
@@ -9,11 +9,10 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/"
 export PYTHONPATH=${PASH_TOP}/python_pkgs/
 export PASH_TIMESTAMP="$(date +"%y-%m-%d-%T")"
 
-# add hdfs directory if hdfs command exist
+# Add hdfs support if hdfs command exist
 if command -v "hdfs" &> /dev/null
 then
-    datanode_dir=$(hdfs getconf -confKey dfs.datanode.data.dir) 
-    export HDFS_DATANODE_DIR=${datanode_dir#"file://"} # removes file:// prefix
+    source "$PASH_TOP/compiler/dspash/hdfs_utils.sh"
 fi
 
 source "$PASH_TOP/compiler/pash_init_setup.sh" $@ --distributed_exec

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -308,6 +308,12 @@ class IR:
         else:
             return None
 
+    def get_edge_to(self, edge_id):
+        if(edge_id in self.edges):
+            return self.edges[edge_id][2]
+        else:
+            return None
+
     def replace_edge(self, old_edge_id, new_edge_fid):
         assert(new_edge_fid not in self.all_fids())
         new_edge_id = new_edge_fid.get_ident()

--- a/compiler/pash_runtime.py
+++ b/compiler/pash_runtime.py
@@ -21,6 +21,7 @@ import definitions.ir.nodes.r_merge as r_merge
 import definitions.ir.nodes.r_split as r_split
 import definitions.ir.nodes.r_unwrap as r_unwrap
 import definitions.ir.nodes.dgsh_tee as dgsh_tee
+import definitions.ir.nodes.remote_pipe as remote_pipe
 import definitions.ir.nodes.dfs_split_reader as dfs_split_reader
 # Distirbuted Exec
 import dspash.hdfs_utils as hdfs_utils 
@@ -767,6 +768,12 @@ def add_eager_nodes(graph, use_dgsh_tee):
 
             ## Add an eager after r_split
             if(isinstance(curr, r_split.RSplit)):
+                eager_input_ids = curr.outputs
+                for edge_id in eager_input_ids:
+                    add_eager(edge_id, graph, fileIdGen, intermediateFileIdGen, use_dgsh_tee)
+
+            ## Add an eager after remote_pipe
+            if(isinstance(curr, remote_pipe.RemotePipe)):
                 eager_input_ids = curr.outputs
                 for edge_id in eager_input_ids:
                     add_eager(edge_id, graph, fileIdGen, intermediateFileIdGen, use_dgsh_tee)

--- a/compiler/pash_runtime.py
+++ b/compiler/pash_runtime.py
@@ -397,7 +397,7 @@ def split_hdfs_cat_input(hdfs_cat, next_node, graph, fileIdGen, fan_out, r_split
             output_ids.append(output_fid.get_ident())
             graph.add_edge(output_fid)
 
-            split_reader_node = dfs_split_reader.make_dfs_split_reader_node([block_fid.get_ident()], output_fid.get_ident(), split_num, config.HDFS_PREFIX)
+            split_reader_node = dfs_split_reader.make_dfs_split_reader_node([block_fid.get_ident()], output_fid.get_ident(), split_num)
             graph.add_node(split_reader_node)
 
     # Remove the HDFS Cat command as it's not used anymore

--- a/compiler/pash_runtime.py
+++ b/compiler/pash_runtime.py
@@ -363,7 +363,7 @@ def split_command_input(curr, graph, fileIdGen, fan_out, _batch_size, r_split_fl
 
     return new_merger
 
-def split_hdfs_cat_input(hdfs_cat, next_node, graph, fileIdGen):
+def split_hdfs_cat_input(hdfs_cat, next_node, graph, fileIdGen, fan_out, r_split_flag, r_split_batch_size ):
     """
     Replaces hdfs cat with a cat per block, each cat uses has an HDFSResource input fid
     Returns: A normal Cat that merges the blocks (will be removed when parallizing next_node)
@@ -374,27 +374,30 @@ def split_hdfs_cat_input(hdfs_cat, next_node, graph, fileIdGen):
     if len(next_node.get_standard_inputs()) != 1:
         return
 
-    hdfscat_input_id = hdfs_cat.get_standard_inputs()[0]
-    hdfs_fid = graph.get_edge_fid(hdfscat_input_id)
-    hdfs_filepath = str(hdfs_fid.get_resource())
-    output_ids = []
+    output_ids = [] # Stores all the output edges from splitting to blocks
 
-    # Create a cat command per file block
-    file_config = hdfs_utils.get_file_config(hdfs_filepath)
-    _, dummy_config_path = ptempfile() # Dummy config file, should be updated by workers
-    for split_num, block in enumerate(file_config.blocks):
-        resource = DFSSplitResource(file_config.dumps(), dummy_config_path, split_num, block.hosts)
-        block_fid = fileIdGen.next_file_id()
-        block_fid.set_resource(resource)
-        graph.add_edge(block_fid)
+    # The for loop handles the case of multiple inputs to cat (i.e hdfscat A B)
+    for hdfscat_input_id in hdfs_cat.get_standard_inputs():
+        hdfs_fid = graph.get_edge_fid(hdfscat_input_id)
+        hdfs_filepath = str(hdfs_fid.get_resource())
+    
 
-        output_fid = fileIdGen.next_file_id()
-        output_fid.make_ephemeral()
-        output_ids.append(output_fid.get_ident())
-        graph.add_edge(output_fid)
+        # Create a cat command per file block
+        file_config = hdfs_utils.get_file_config(hdfs_filepath)
+        _, dummy_config_path = ptempfile() # Dummy config file, should be updated by workers
+        for split_num, block in enumerate(file_config.blocks):
+            resource = DFSSplitResource(file_config.dumps(), dummy_config_path, split_num, block.hosts)
+            block_fid = fileIdGen.next_file_id()
+            block_fid.set_resource(resource)
+            graph.add_edge(block_fid)
 
-        split_reader_node = dfs_split_reader.make_dfs_split_reader_node([block_fid.get_ident()], output_fid.get_ident(), split_num, config.HDFS_PREFIX)
-        graph.add_node(split_reader_node)
+            output_fid = fileIdGen.next_file_id()
+            output_fid.make_ephemeral()
+            output_ids.append(output_fid.get_ident())
+            graph.add_edge(output_fid)
+
+            split_reader_node = dfs_split_reader.make_dfs_split_reader_node([block_fid.get_ident()], output_fid.get_ident(), split_num, config.HDFS_PREFIX)
+            graph.add_node(split_reader_node)
 
     # Remove the HDFS Cat command as it's not used anymore
     graph.remove_node(hdfs_cat.get_id())
@@ -403,6 +406,10 @@ def split_hdfs_cat_input(hdfs_cat, next_node, graph, fileIdGen):
     input_id = next_node.get_standard_inputs()[0]
     new_merger = make_cat_node(output_ids, input_id)
     graph.add_node(new_merger)
+
+    # If the file is only one block, we follow by a normal split
+    if (len(output_ids) == 1):
+        new_merger = split_command_input(next_node, graph, fileIdGen, fan_out, "unused", r_split_flag, r_split_batch_size)
 
     return new_merger
 
@@ -449,7 +456,7 @@ def parallelize_cat(curr_id, graph, fileIdGen, fan_out,
             ## If the current node is not a merger, it means that we need
             ## to generate a merger using a splitter (auto_split or r_split)
             if (isinstance(curr, HDFSCat) and config.pash_args.distributed_exec):
-                new_curr = split_hdfs_cat_input(curr, next_node, graph, fileIdGen) # Cat merger
+                new_curr = split_hdfs_cat_input(curr, next_node, graph, fileIdGen, fan_out, r_split_flag, r_split_batch_size) # Cat merger
                 new_curr_id = new_curr.get_id()
             ## no_cat_split_vanish shortcircuits this and inserts a split even if the current node is a cat.
             elif (fan_out > 1

--- a/runtime/dspash/file_reader/client/dfs_split_reader.go
+++ b/runtime/dspash/file_reader/client/dfs_split_reader.go
@@ -87,7 +87,7 @@ func readFirstLine(block DFSBlock, writer *bufio.Writer) (ok bool, e error) {
 
 func getAbsPath(s string) (string, error) {
 	// Hacky but should work for now
-	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo %s", s)).Output()
+	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo -n %s", s)).Output()
 	if err != nil {
 		return "", err
 	}
@@ -133,6 +133,7 @@ func readDFSLogicalSplit(conf DFSConfig, split int) error {
 		return err
 	}
 
+	fmt.Println(filepath)
 	err = readLocalFile(filepath, skipFirstLine, writer)
 	if err != nil {
 		return err

--- a/runtime/dspash/file_reader/client/dfs_split_reader.go
+++ b/runtime/dspash/file_reader/client/dfs_split_reader.go
@@ -133,7 +133,6 @@ func readDFSLogicalSplit(conf DFSConfig, split int) error {
 		return err
 	}
 
-	fmt.Println(filepath)
 	err = readLocalFile(filepath, skipFirstLine, writer)
 	if err != nil {
 		return err

--- a/runtime/dspash/file_reader/client/dfs_split_reader.go
+++ b/runtime/dspash/file_reader/client/dfs_split_reader.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/exec"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -85,15 +84,6 @@ func readFirstLine(block DFSBlock, writer *bufio.Writer) (ok bool, e error) {
 	return
 }
 
-func getAbsPath(s string) (string, error) {
-	// Hacky but should work for now
-	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo -n %s", s)).Output()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
 func readLocalFile(p string, skipFirstLine bool, writer *bufio.Writer) error {
 	file, err := os.Open(p)
 	if err != nil {
@@ -128,7 +118,7 @@ func readDFSLogicalSplit(conf DFSConfig, split int) error {
 		skipFirstLine = false
 	}
 
-	filepath, err := getAbsPath(conf.Blocks[split].Path)
+	filepath, err := pb.GetAbsPath(conf.Blocks[split].Path)
 	if err != nil {
 		return err
 	}

--- a/runtime/dspash/file_reader/client/dfs_split_reader.go
+++ b/runtime/dspash/file_reader/client/dfs_split_reader.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -21,7 +22,6 @@ var (
 	config     = flag.String("config", "", "File to read")
 	splitNum   = flag.Int("split", 0, "The logical split number")
 	serverPort = flag.Int("port", 50051, "The server port, all machines should use same port")
-	prefix     = flag.String("prefix", "", "The top directory")
 )
 
 // Distrubted file system block
@@ -55,7 +55,7 @@ func readFirstLine(block DFSBlock, writer *bufio.Writer) (ok bool, e error) {
 
 		client := pb.NewFileReaderClient(conn)
 
-		stream, err := client.ReadFile(ctx, &pb.FileRequest{Path: *prefix + block.Path})
+		stream, err := client.ReadFile(ctx, &pb.FileRequest{Path: block.Path})
 		if err != nil {
 			continue
 		}
@@ -85,8 +85,13 @@ func readFirstLine(block DFSBlock, writer *bufio.Writer) (ok bool, e error) {
 	return
 }
 
-func getAbsPath(s string) string {
-	return os.ExpandEnv(*prefix + s)
+func getAbsPath(s string) (string, error) {
+	// Hacky but should work for now
+	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo %s", s)).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }
 
 func readLocalFile(p string, skipFirstLine bool, writer *bufio.Writer) error {
@@ -123,7 +128,12 @@ func readDFSLogicalSplit(conf DFSConfig, split int) error {
 		skipFirstLine = false
 	}
 
-	err := readLocalFile(getAbsPath(conf.Blocks[split].Path), skipFirstLine, writer)
+	filepath, err := getAbsPath(conf.Blocks[split].Path)
+	if err != nil {
+		return err
+	}
+
+	err = readLocalFile(filepath, skipFirstLine, writer)
 	if err != nil {
 		return err
 	}

--- a/runtime/dspash/file_reader/filereader/utils.go
+++ b/runtime/dspash/file_reader/filereader/utils.go
@@ -1,0 +1,15 @@
+package filereader
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func GetAbsPath(s string) (string, error) {
+	// Hacky but should work for now
+	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo -n %s", s)).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/runtime/dspash/file_reader/server/server.go
+++ b/runtime/dspash/file_reader/server/server.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/exec"
 
 	"google.golang.org/grpc"
 
@@ -24,17 +23,8 @@ type fileReaderServer struct {
 	pb.UnimplementedFileReaderServer
 }
 
-func getAbsPath(s string) (string, error) {
-	// Hacky but should work for now
-	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo %s", s)).Output()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
 func (s *fileReaderServer) ReadFile(req *pb.FileRequest, stream pb.FileReader_ReadFileServer) error {
-	filename, err := getAbsPath(req.path)
+	filename, err := pb.GetAbsPath(req.Path)
 	if err != nil {
 		log.Println(err)
 		return err

--- a/runtime/dspash/file_reader/server/server.go
+++ b/runtime/dspash/file_reader/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/exec"
 
 	"google.golang.org/grpc"
 
@@ -23,8 +24,23 @@ type fileReaderServer struct {
 	pb.UnimplementedFileReaderServer
 }
 
+func getAbsPath(s string) (string, error) {
+	// Hacky but should work for now
+	out, err := exec.Command("bash", "-c", fmt.Sprintf("echo %s", s)).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
 func (s *fileReaderServer) ReadFile(req *pb.FileRequest, stream pb.FileReader_ReadFileServer) error {
-	file, err := os.Open(os.ExpandEnv(req.Path))
+	filename, err := getAbsPath(req.path)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	file, err := os.Open(filename)
 	if err != nil {
 		log.Println(err)
 		return err

--- a/scripts/setup-dspash.sh
+++ b/scripts/setup-dspash.sh
@@ -1,5 +1,4 @@
 
-# TODO: install any extra needed python debs
 
 # Get PASH_TOP
 if git rev-parse --git-dir > /dev/null 2>&1; then
@@ -9,6 +8,11 @@ else
     # set PASH_TOP to the root folder of the project if it is not available
     PASH_TOP=${PASH_TOP:-$PWD/..}
 fi
+
+
+# TODO: install any extra needed python debs
+PYTHON_PKG_DIR=$PASH_TOP/python_pkgs
+python3 -m pip install requests --root $PYTHON_PKG_DIR --ignore-installed
 
 # Install Go
 wget https://go.dev/dl/go1.17.7.linux-amd64.tar.gz

--- a/scripts/setup-dspash.sh
+++ b/scripts/setup-dspash.sh
@@ -9,7 +9,7 @@ fi
 
 
 # TODO: install any extra needed python debs
-pip3 install requests
+pip install --target=${PASH_TOP}/python_pkgs/ requests
 
 # Install Go
 wget https://go.dev/dl/go1.17.7.linux-amd64.tar.gz

--- a/scripts/setup-dspash.sh
+++ b/scripts/setup-dspash.sh
@@ -1,5 +1,3 @@
-
-
 # Get PASH_TOP
 if git rev-parse --git-dir > /dev/null 2>&1; then
     # set PASH_TOP
@@ -11,8 +9,7 @@ fi
 
 
 # TODO: install any extra needed python debs
-PYTHON_PKG_DIR=$PASH_TOP/python_pkgs
-python3 -m pip install requests --root $PYTHON_PKG_DIR --ignore-installed
+pip3 install requests
 
 # Install Go
 wget https://go.dev/dl/go1.17.7.linux-amd64.tar.gz

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -91,6 +91,7 @@ python3 -m pip install jsonpickle --root $PYTHON_PKG_DIR --ignore-installed #&> 
 python3 -m pip install pexpect --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_pexpect.log
 python3 -m pip install numpy --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_numpy.log
 python3 -m pip install matplotlib --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_matplotlib.log
+python3 -m pip install requests --root $PYTHON_PKG_DIR --ignore-installed
 
 # clean the python packages
 cd $PYTHON_PKG_DIR


### PR DESCRIPTION
Fixes many bugs and reliability problems:
- Support multiple inputs in hdfs cat "hdfs dfs -cat $IN1 $IN2 .."
- Fix bugs with multi sink scripts
- Support HDFS blocks that are not stored in subdir0 locally
- Merge graph on one worker on the first aggregator (Performance improvement)
- Use processes instead of threads in workers (fixed hanging issue)
- Fixes other bugs and edge cases in graph splitting
- Setup and Installation scripts improvements