### PR TITLE
Fix bug in parallel pipelines caused by false reporting of fids

### DIFF
--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -583,19 +583,20 @@ class IR:
 
     ## Returns all the file identifiers in the IR.
     def all_fids(self):
-        all_fids = [fid for fid, _from_node, _to_node in self.edges.values()]
+        all_fids = [fid for fid, from_node, to_node in self.edges.values() 
+                        if (from_node is not None or to_node is not None)]
         return all_fids
 
     ## Returns all input fids of the IR
     def all_input_fids(self):
-        all_input_fids = [fid for fid, from_node, _to_node in self.edges.values()
-                          if from_node is None]
+        all_input_fids = [fid for fid, from_node, to_node in self.edges.values()
+                          if from_node is None and to_node is not None]
         return all_input_fids
 
     ## Returns all output fids of the IR
     def all_output_fids(self):
-        all_output_fids = [fid for fid, _from_node, to_node in self.edges.values()
-                          if to_node is None]
+        all_output_fids = [fid for fid, from_node, to_node in self.edges.values()
+                          if to_node is None and from_node is not None]
         return all_output_fids
 
     ## Returns the sources of the IR.


### PR DESCRIPTION
Fids with no input or output nodes were reported as output fids and input fids causing some conflicts in parallel pipelines (specifically in the distributed execution mode since we replace hdfs cat input fids with an input per block).

Note: this is not a complete solution. replacing HDFSCat with per block cat could cause some conflicts to go undetected. Example: (x | x | x | hdfs dfs -put -f - /1.txt; hdfs dfs -cat) where /1.txt existed before.