### PR TITLE
add --depth=1 flag to git clone command

### DIFF
--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -17,10 +17,10 @@ if [ "$PLATFORM" = "darwin" ]; then
 fi
 
 set +e
-git clone git@github.com:binpash/pash.git
+git clone --depth 1 git@github.com:binpash/pash.git
 if [ $? -ne 0 ]; then
   echo 'SSH clone failed; attempting HTTPS'
-  git clone https://github.com/andromeda/pash.git
+  git clone --depth 1 https://github.com/andromeda/pash.git
 fi
 set -e
 


### PR DESCRIPTION
we don't need the entire git history to run `pash`, so pulling only the latest files speeds things up and reduces the network load (especially as the repo's commit history grows)