### PR TITLE
add --depth=1 flag to git clone command

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -3,7 +3,7 @@
 On Ubuntu, Fedora, Debian, or Arch, run `curl up.pash.ndr.md | sh` to get PaSh up and running.
 
 If on other environments or prefer manual setup, there are essentially three steps required to set PaSh up:
-1. Clone repo: `git clone git@github.com:binpash/pash.git`
+1. Clone repo: `git clone --depth 1 git@github.com:binpash/pash.git`
 2. Run `distro-deps.sh` (with `sudo`) and `setup-pash.sh`
 3. Export `PASH_TOP` and, optionally, add it to your `PATH`
 
@@ -18,7 +18,7 @@ Quick Jump: [Clone & Setup](#) | [Manual Setup](#manual-setup) | [Docker Setup](
 The following steps clone the repo, set up dependencies (e.g., compilers), and then build PaSh:
 
 ```sh
-git clone git@github.com:binpash/pash.git
+git clone --depth 1 git@github.com:binpash/pash.git
 sudo pash/scripts/distro-deps.sh
 ./pash/scripts/setup-pash.sh
 ```
@@ -36,7 +36,7 @@ automake bc bsdmainutils curl gcc git libffi-dev libtool locales locales-all m4 
 Then clone the PaSh repository and run `setup-pash.sh` as follows:
 
 ```sh
-git clone git@github.com:binpash/pash.git
+git clone --depth 1 git@github.com:binpash/pash.git
 ./pash/scripts/setup-pash.sh
 ```
 
@@ -60,7 +60,7 @@ We refresh this image (as well as other images) on every major release.
 _Build Image (Latest Commit):_
 To build the latest Docker container, run `docker build` in [scripts/docker](https://github.com/binpash/pash/tree/main/scripts/docker):
 ```sh
-git clone git@github.com:binpash/pash.git
+git clone --depth 1 git@github.com:binpash/pash.git
 cd pash/scripts/docker/
 docker build -f ./ubuntu/Dockerfile -t "pash:latest" .
 ```

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -21,7 +21,7 @@ To restart after you exit, run `docker start -i pash-play`
 ## From PaSh's Official docker
 
 ```sh
-git clone git@github.com:binpash/pash.git
+git clone --depth 1 git@github.com:binpash/pash.git
 cd pash/scripts/docker
 docker build -t "pash:latest" .
 ```

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:10
 RUN apt-get update -y && apt-get install -y git
 ENV PASH_TOP=/opt/pash
 # download PaSh
-RUN git clone https://github.com/binpash/pash.git /opt/pash
+RUN git clone --depth 1 https://github.com/binpash/pash.git /opt/pash
 RUN bash /opt/pash/scripts/distro-deps.sh -o 
 RUN yes | bash /opt/pash/scripts/setup-pash.sh -o
 ENV LANG en_US.UTF-8

--- a/scripts/docker/fedora/Dockerfile
+++ b/scripts/docker/fedora/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:35
 RUN dnf install git -y
 ENV PASH_TOP=/opt/pash
 # download PaSh
-RUN git clone https://github.com/binpash/pash.git /opt/pash
+RUN git clone --depth 1 https://github.com/binpash/pash.git /opt/pash
 RUN bash /opt/pash/scripts/distro-deps.sh -o 
 RUN yes | bash /opt/pash/scripts/setup-pash.sh -o
 ENV LANG en_US.UTF-8

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 RUN apt-get update -y && apt-get install -y git
 ENV PASH_TOP=/opt/pash
 # download PaSh
-RUN git clone https://github.com/binpash/pash.git /opt/pash
+RUN git clone --depth 1 https://github.com/binpash/pash.git /opt/pash
 RUN bash /opt/pash/scripts/distro-deps.sh -o 
 RUN yes | bash /opt/pash/scripts/setup-pash.sh -o
 ENV LANG en_US.UTF-8

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -16,7 +16,7 @@ else
     # remove previous installation if it exists
     rm -rf $PASH_TOP/compiler/parser/libdash
     # we are in package mode, no .git information is available
-    git clone https://github.com/angelhof/libdash/ $PASH_TOP/compiler/parser/libdash
+    git clone --depth 1 https://github.com/angelhof/libdash/ $PASH_TOP/compiler/parser/libdash
 fi
 cd $PASH_TOP
 . "$PASH_TOP/scripts/utils.sh"

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -17,10 +17,10 @@ if [ "$PLATFORM" = "darwin" ]; then
 fi
 
 set +e
-git clone git@github.com:binpash/pash.git
+git clone --depth 1 git@github.com:binpash/pash.git
 if [ $? -ne 0 ]; then
   echo 'SSH clone failed; attempting HTTPS'
-  git clone https://github.com/andromeda/pash.git
+  git clone --depth 1 https://github.com/andromeda/pash.git
 fi
 set -e
 


### PR DESCRIPTION
we don't need the entire git history to run pash, so pulling only the latest files speeds things up and reduces the network load (especially as the repo's commit history grows)

Signed-off-by: Avery <averykhoo@gmail.com>