### PR TITLE
Drop function kw

### DIFF
--- a/compiler/dspash/worker.sh
+++ b/compiler/dspash/worker.sh
@@ -20,7 +20,7 @@ source "$PASH_TOP/compiler/pash_init_setup.sh" "$@" --distributed_exec
 
 export PASH_TMP_PREFIX="$(mktemp -d /tmp/pash_XXXXXXX)/"
 
-function cleanup() {
+cleanup() {
         kill "$FILEREADER_PID" "$DISCOVERY_PID"
         wait "$FILEREADER_PID" "$DISCOVERY_PID" 2>/dev/null
         rm -rf "$PASH_TMP_PREFIX"

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -15,7 +15,7 @@ log()
 
 # Taken from: https://stackoverflow.com/a/20473191
 # list_include_item "10 11 12" "2"
-function list_include_item {
+list_include_item {
   local list="$1"
   local item="$2"
   if [[ $list =~ (^|[[:space:]])"$item"($|[[:space:]]) ]] ; then

--- a/compiler/pash_runtime_quick_abort.sh
+++ b/compiler/pash_runtime_quick_abort.sh
@@ -15,7 +15,7 @@ log()
 
 # Taken from: https://stackoverflow.com/a/20473191
 # list_include_item "10 11 12" "2"
-list_include_item {
+list_include_item() {
   local list="$1"
   local item="$2"
   if [[ $list =~ (^|[[:space:]])"$item"($|[[:space:]]) ]] ; then

--- a/evaluation/osdi22-eval/run_all.sh
+++ b/evaluation/osdi22-eval/run_all.sh
@@ -59,7 +59,7 @@ run_bench() {
     done
 }
 
-function run_all_benchmarks() {
+run_all_benchmarks() {
   # generate output folder for each run
   export RES_FOLDER=$1
   # clean previous runs

--- a/evaluation/other/circular/sq.sh
+++ b/evaluation/other/circular/sq.sh
@@ -2,6 +2,7 @@
 # Clever trick that uses the /dev/fd/xx pseudo-file system
 # https://stackoverflow.com/questions/40244/how-to-make-a-pipe-loop-in-bash
 
+# MMG 2022-06-30 the `function` kw is a bash-ism; leaving it in to not disrupt what gets optimized in previous evaluations
 function calc() {
   # calculate sum of squares of numbers 0,..,10
 

--- a/pa.sh
+++ b/pa.sh
@@ -8,7 +8,7 @@ export PYTHONPATH=${PASH_TOP}/python_pkgs/
 trap kill_all SIGTERM SIGINT
 
 ## kill all the pending processes that are spawned by this shell
-function kill_all() {
+kill_all() {
     # kill all my subprocesses only
     kill -s SIGKILL 0
     # kill pash_daemon


### PR DESCRIPTION
A variety of scripts use the `function` keyword to define functions, which isn't POSIX. This PR drops that keyword from all scripts except for `other/circular/sq.sh` (I wanted to preserve that for evaluation).

It's not an issue per se---these scripts are already in `bash`, so there's no serious harm in having it there... except I was using those scripts to test the libdash bindings, and it broke them.