### PR TITLE
Run tests in Ubuntu 18.04 and 20.04 to completion

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ on:
 jobs:
     Pash-Tests:
       strategy:
+        fail-fast: false
         matrix:
           os: 
             - ubuntu-18.04


### PR DESCRIPTION
Currently we're using the default `fail-fast: true`, but this means a failure due to 18.04's Python 3.6 in #616 means we can't see how 20.04 does.

Debugging CI sucks lol.