### PR TITLE
Don't run PaSh Github CI on Ubuntu 18.04 due to deprecation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,8 @@ jobs:
         fail-fast: false
         matrix:
           os: 
-            - ubuntu-18.04
             - ubuntu-20.04
+            - ubuntu-22.04
       runs-on: ${{ matrix.os }}
       if: github.event.pull_request.draft == false
       steps:


### PR DESCRIPTION
Github Actions are deprecating Ubuntu 18.04 (https://github.com/actions/runner-images/issues/6002), which was already causing us issues due to an old Python version (3.6). Therefore, we can just remove it from the CI and run on Ubuntu 20 and 22 instead