### PR TITLE
Remove pexpect and add a deprecation warning

### DIFF
--- a/compiler/expand.py
+++ b/compiler/expand.py
@@ -247,13 +247,6 @@ def lookup_variable(var, _lookup_config):
     ##           eval "$cmd"
 
 
-    ## Only check the cache if we are using bash mirror
-    if config.pash_args.expand_using_bash_mirror:
-        ## If we find the value in the cache just use it
-        var_value = config.get_from_variable_cache(var)
-        if var_value is not None:
-            return None, var_value
-
     if(var == '@'):
         argument_values = lookup_variable_inner_core('pash_input_args')
         expanded_var = " ".join(argument_values)
@@ -282,10 +275,6 @@ def lookup_variable(var, _lookup_config):
         ## TODO: We can pull this to expand any string.
         expanded_var = lookup_variable_inner(var)
     
-    ## Add it to the cache to find it next time
-    if config.pash_args.expand_using_bash_mirror:
-        config.add_to_variable_cache(var, expanded_var)
-
     return None, expanded_var
 
 ## Looksup a variable and flattens it if it is an array 
@@ -307,12 +296,9 @@ def lookup_variable_inner_core(varname):
 
 
 def lookup_variable_inner_unsafe(varname):
-    if config.pash_args.expand_using_bash_mirror:
-        return config.query_expand_variable_bash_mirror(varname)
-    else:
-        ## TODO: Is it in there? If we have -u and it is in there.
-        _type, value = config.config['shell_variables'].get(varname, [None, None])
-        return value
+    ## TODO: Is it in there? If we have -u and it is in there.
+    _type, value = config.config['shell_variables'].get(varname, [None, None])
+    return value
 
 ## This function checks if the -u flag is set
 def is_u_set():

--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -167,7 +167,12 @@ def parse_args():
     parser.add_argument("-x",
                         help="(experimental) prints commands and their arguments as they execute",
                         action="store_true")
-    
+    ## Deprecated argument... keeping here just to output the message
+    ## TODO: Do that with a custom argparse Action (KK: I tried and failed)
+    parser.add_argument("--expand_using_bash_mirror",
+                        help="DEPRECATED: instead of expanding using the internal expansion code, expand using a bash mirror process (slow)",
+                        action="store_true")
+
     config.add_common_arguments(parser)
     args = parser.parse_args()
     config.pash_args = args
@@ -185,6 +190,10 @@ def parse_args():
     for arg_name, arg_val in vars(args).items():
         log(arg_name, arg_val)
     log("-" * 40)
+
+    ## Print the deprecated argument
+    if args.expand_using_bash_mirror:
+        log("WARNING: Option --expand_using_bash_mirror is deprecated and is *ignored*.", level=0)
 
     ## TODO: We might need to have a better default (like $0 of pa.sh)
     shell_name = "pash"

--- a/scripts/setup-pash.sh
+++ b/scripts/setup-pash.sh
@@ -21,7 +21,6 @@ mkdir -p $PYTHON_PKG_DIR
 echo "Installing python dependencies..."
 
 python3 -m pip install jsonpickle --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_jsonpickle.log
-python3 -m pip install pexpect --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_pexpect.log
 python3 -m pip install graphviz --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_graphviz.log
 python3 -m pip install numpy --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_numpy.log
 python3 -m pip install matplotlib --root $PYTHON_PKG_DIR --ignore-installed #&> $LOG_DIR/pip_install_matplotlib.log


### PR DESCRIPTION
The `pexpect` import is no longer needed since it was only used to evaluate a slower configuration of PaSh. I removed pexpect from the installation and from everywhere in PaSh.

Signed-off-by: Konstantinos Kallas <konstantinos.kallas@hotmail.com>