### PR TITLE
Replace python with python3 package

### DIFF
--- a/scripts/distro-deps.sh
+++ b/scripts/distro-deps.sh
@@ -28,7 +28,7 @@ fi
 # convert to lowercase
 distro=$(printf '%s\n' "$distro" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 # compile the list of the shared required packages
-pkgs="bc curl git graphviz python sudo wget"
+pkgs="bc curl git graphviz python3 sudo wget"
 # now do different things depending on distro
 case "$distro" in
     ubuntu*)  


### PR DESCRIPTION
Package python causes issues on Ubuntu Linux when running `sudo pash/scripts/distro-deps.sh` during installation, python3 works.