### PR TITLE
Trigger CI on scripts changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
         - runtime/**
         - evaluation/**
         - annotations/**
+        - scripts/**
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
         - runtime/**
         - evaluation/**
         - annotations/**
+        - scripts/**
 
 # Jobs section
 jobs:

--- a/.github/workflows/posix.yaml
+++ b/.github/workflows/posix.yaml
@@ -8,6 +8,7 @@ on:
           - runtime/**
           - evaluation/**
           - annotations/**
+          - scripts/**
 jobs:
   issue-jobs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
         - runtime/**
         - evaluation/**
         - annotations/**
+        - scripts/**
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
         - runtime/**
         - evaluation/**
         - annotations/**
+        - scripts/**
 
 # Jobs section
 jobs:

--- a/.github/workflows/tight-loop.yaml
+++ b/.github/workflows/tight-loop.yaml
@@ -10,6 +10,7 @@ on:
       - runtime/**
       - evaluation/**
       - annotations/**
+      - scripts/**
 
   pull_request_target:
     types: [assigned, opened, synchronize, reopened, ready_for_review]
@@ -19,6 +20,7 @@ on:
           - runtime/**
           - evaluation/**
           - annotations/**
+          - scripts/**
 
 # Jobs section
 jobs:


### PR DESCRIPTION
There is no benefit in not triggering CI on scripts changes. We are often required to do whitespace changes to trigger it.