### PR TITLE
Allow preprocessor to extract sequence of commands

### DIFF
--- a/compiler/pash.py
+++ b/compiler/pash.py
@@ -40,8 +40,7 @@ def main():
         sys.exit(return_code)
 
 def preprocess_and_execute_asts(input_script_path, args, input_script_arguments, shell_name):
-    mode = ast_to_ast.TransformationType('pash')
-    preprocessed_shell_script = preprocess(input_script_path, args, mode)
+    preprocessed_shell_script = preprocess(input_script_path, args)
     if(args.output_preprocessed):
         log("Preprocessed script:")
         log(preprocessed_shell_script)
@@ -156,6 +155,9 @@ def parse_args():
     parser.add_argument("--expand_using_bash_mirror",
                         help="DEPRECATED: instead of expanding using the internal expansion code, expand using a bash mirror process (slow)",
                         action="store_true")
+
+    ## Set the preprocessing mode to PaSh
+    parser.set_defaults(preprocess_mode='pash')
 
     config.add_common_arguments(parser)
     args = parser.parse_args()

--- a/compiler/preprocessor/preprocessor.py
+++ b/compiler/preprocessor/preprocessor.py
@@ -7,11 +7,12 @@ from shell_ast import ast_to_ast
 from ir import FileIdGen
 from parse import parse_shell_to_asts, from_ast_objects_to_shell
 from util import *
+from util_spec import *
 
 LOGGING_PREFIX = "PaSh Preprocessor: "
 
 @logging_prefix(LOGGING_PREFIX)
-def preprocess(input_script_path, args, mode):
+def preprocess(input_script_path, args):
     ## 1. Execute the POSIX shell parser that returns the AST in JSON
     preprocessing_parsing_start_time = datetime.now()
     ast_objects = parse_shell_to_asts(input_script_path)
@@ -21,7 +22,7 @@ def preprocess(input_script_path, args, mode):
     ## 2. Preprocess ASTs by replacing possible candidates for compilation
     ##    with calls to the PaSh runtime.
     preprocessing_pash_start_time = datetime.now()
-    preprocessed_asts = preprocess_asts(ast_objects, mode)
+    preprocessed_asts = preprocess_asts(ast_objects, args)
     preprocessing_pash_end_time = datetime.now()
     print_time_delta("Preprocessing -- PaSh", preprocessing_pash_start_time, preprocessing_pash_end_time)
 
@@ -34,14 +35,18 @@ def preprocess(input_script_path, args, mode):
     return preprocessed_shell_script
 
 
-def preprocess_asts(ast_objects, mode):
+def preprocess_asts(ast_objects, args):
 
-    ## TODO: Add a potential selection here to decide what kind of transformation to apply
+    
+    trans_options = ast_to_ast.TransformationOptions(args)
+
+    if trans_options.get_mode() is ast_to_ast.TransformationType.SPECULATIVE:
+        initialize_po_file(trans_options)
 
     ## Preprocess ASTs by replacing AST regions with calls to PaSh's runtime.
     ## Then the runtime will do the compilation and optimization with additional
     ## information.
-    preprocessed_asts = ast_to_ast.replace_ast_regions(ast_objects, mode)
+    preprocessed_asts = ast_to_ast.replace_ast_regions(ast_objects, trans_options)
 
     return preprocessed_asts
 
@@ -50,9 +55,24 @@ def preprocess_asts(ast_objects, mode):
 ##
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("input", help="the script to be preprocessed")
     config.add_general_config_arguments(parser)
 
+    subparsers = parser.add_subparsers(help='sub-command help')
+
+    # create the parser for the "a" command
+    parser_pash = subparsers.add_parser('pash', help='Preprocess the script so that it can be run with PaSh')
+    config.add_common_arguments(parser_pash)
+    parser_pash.add_argument("input", help="the script to be preprocessed")
+    parser_pash.set_defaults(mode='pash')
+
+    # create the parser for the "b" command
+    parser_spec = subparsers.add_parser('spec', help='Preprocess the script so that it can be run with speculation')
+    parser_spec.add_argument("input", help="the script to be preprocessed")
+
+    ## TODO: When we better integrate, this should be automatically set.
+    parser_spec.add_argument("partial_order_file", help="the file to store the partial order (currently just a sequence)")
+    parser_spec.set_defaults(mode='spec')
+    
     args = parser.parse_args()
     config.set_config_globals_from_pash_args(args)
 
@@ -60,10 +80,9 @@ def main():
     ## TODO: Can we move this somewhere where there is no need for copy paste?
     config.init_log_file()
 
-    ## TODO: Modify this to allow for multiple different transformation types 
-    ##       (and potentially being more loosely coupled with PaSh).
-    mode = ast_to_ast.TransformationType('spec')
-    preprocessed_shell_script = preprocess(args.input, args, mode)
+    ## Choose the transformation node based on the argument given
+    log("Preprocesing mode:", args.mode)
+    preprocessed_shell_script = preprocess(args.input, args)
     print(preprocessed_shell_script)
 
 if __name__ == '__main__':

--- a/compiler/preprocessor/preprocessor.py
+++ b/compiler/preprocessor/preprocessor.py
@@ -36,8 +36,6 @@ def preprocess(input_script_path, args):
 
 
 def preprocess_asts(ast_objects, args):
-
-    
     trans_options = ast_to_ast.TransformationOptions(args)
 
     if trans_options.get_mode() is ast_to_ast.TransformationType.SPECULATIVE:
@@ -63,7 +61,7 @@ def main():
     parser_pash = subparsers.add_parser('pash', help='Preprocess the script so that it can be run with PaSh')
     config.add_common_arguments(parser_pash)
     parser_pash.add_argument("input", help="the script to be preprocessed")
-    parser_pash.set_defaults(mode='pash')
+    parser_pash.set_defaults(preprocess_mode='pash')
 
     # create the parser for the "b" command
     parser_spec = subparsers.add_parser('spec', help='Preprocess the script so that it can be run with speculation')
@@ -71,7 +69,7 @@ def main():
 
     ## TODO: When we better integrate, this should be automatically set.
     parser_spec.add_argument("partial_order_file", help="the file to store the partial order (currently just a sequence)")
-    parser_spec.set_defaults(mode='spec')
+    parser_spec.set_defaults(preprocess_mode='spec')
     
     args = parser.parse_args()
     config.set_config_globals_from_pash_args(args)
@@ -81,7 +79,7 @@ def main():
     config.init_log_file()
 
     ## Choose the transformation node based on the argument given
-    log("Preprocesing mode:", args.mode)
+    log("Preprocesing mode:", args.preprocess_mode)
     preprocessed_shell_script = preprocess(args.input, args)
     print(preprocessed_shell_script)
 

--- a/compiler/shell_ast/ast_to_ast.py
+++ b/compiler/shell_ast/ast_to_ast.py
@@ -4,7 +4,7 @@ import pickle
 import config
 
 from shell_ast.ast_util import *
-from parse import from_ast_objects_to_shell_file
+from parse import from_ast_objects_to_shell
 
 
 ## There are two types of ast_to_ast transformations
@@ -15,11 +15,17 @@ class TransformationType(Enum):
 ## Use this object to pass options inside the preprocessing
 ## trasnformation.
 class TransformationOptions:
-    def __init__(self, mode):
-        self.mode = TransformationType(mode)
+    def __init__(self, args):
+        self.mode = TransformationType(args.mode)
+        if self.mode is TransformationType.SPECULATIVE:
+            self.partial_order_file = args.partial_order_file
     
     def get_mode(self):
         return self.mode
+
+    def get_partial_order_file(self):
+        assert(self.mode is TransformationType.SPECULATIVE)
+        return self.partial_order_file
 
 
 ##
@@ -68,9 +74,7 @@ preprocess_cases = {
 
 
 ## Replace candidate dataflow AST regions with calls to PaSh's runtime.
-def replace_ast_regions(ast_objects, mode):
-
-    trans_options = TransformationOptions(mode)
+def replace_ast_regions(ast_objects, trans_options):
 
     preprocessed_asts = []
     candidate_dataflow_region = []
@@ -439,36 +443,44 @@ def preprocess_node_case(ast_node, trans_options, last_object=False):
 ## If we are need to disable parallel pipelines, e.g., if we are in the context of an if,
 ## or if we are in the end of a script, then we set a variable.
 def replace_df_region(asts, trans_options, disable_parallel_pipelines=False, ast_text=None):
-    ir_filename = ptempfile()
-
-    ## Serialize the node in a file
-    with open(ir_filename, "wb") as ir_file:
-        pickle.dump(asts, ir_file)
-
-    ## Serialize the candidate df_region asts back to shell
-    ## so that the sequential script can be run in parallel to the compilation.
-    sequential_script_file_name = ptempfile()
-    ## If we don't have the original ast text, we need to unparse the ast
-    if (ast_text is None):
-        kv_asts = [ast_node_to_untyped_deep(ast) for ast in asts]
-        from_ast_objects_to_shell_file(kv_asts, sequential_script_file_name)
-    else:
-        ## However, if we have the original ast text, then we can simply output that.
-        with open(sequential_script_file_name, "w") as script_file:
-            script_file.write(ast_text)
-
-    ## Replace it with a command that calls the distribution
-    ## planner with the name of the file.
-    ##
-    ## TODO: Modify this here to be conditional based on an argument on the call
     transformation_mode = trans_options.get_mode()
     if transformation_mode is TransformationType.PASH:
+        ir_filename = ptempfile()
+
+        ## Serialize the node in a file
+        with open(ir_filename, "wb") as ir_file:
+            pickle.dump(asts, ir_file)
+
+        ## Serialize the candidate df_region asts back to shell
+        ## so that the sequential script can be run in parallel to the compilation.
+        sequential_script_file_name = ptempfile()
+        text_to_output = get_shell_from_ast(asts, ast_text=ast_text)
+        ## However, if we have the original ast text, then we can simply output that.
+        with open(sequential_script_file_name, "w") as script_file:
+            script_file.write(text_to_output)
         replaced_node = make_call_to_pash_runtime(ir_filename, sequential_script_file_name, disable_parallel_pipelines)
     else:
-        replaced_node = make_call_to_spec_runtime(ir_filename, sequential_script_file_name)
+        ## TODO: This currently writes each command on its own line,
+        ##       though it should be improved to better serialize each command in its own file
+        ##       and then only saving the ids of each command in the partial order file.
+        text_to_output = get_shell_from_ast(asts, ast_text=ast_text)
+        partial_order_file_path = trans_options.get_partial_order_file()
+        with open(partial_order_file_path, "a") as po_file:
+            po_file.write(text_to_output)
+
+        replaced_node = make_call_to_spec_runtime()
 
     return replaced_node
 
+
+def get_shell_from_ast(asts, ast_text=None) -> str:
+    ## If we don't have the original ast text, we need to unparse the ast
+    if (ast_text is None):
+        kv_asts = [ast_node_to_untyped_deep(ast) for ast in asts]
+        text_to_output = from_ast_objects_to_shell(kv_asts)
+    else:
+        text_to_output = ast_text
+    return text_to_output
 ## This function makes a command that calls the pash runtime
 ## together with the name of the file containing an IR. Then the
 ## pash runtime should read from this file and continue
@@ -564,12 +576,14 @@ def make_call_to_pash_runtime(ir_filename, sequential_script_file_name,
     return sequence
 
 ## TODO: Make that an actual call to the spec runtime
-def make_call_to_spec_runtime(ir_filename, sequential_script_file_name) -> AstNode:
-    ## Call the runtime
-    arguments = [string_to_argument("source"),
-                 string_to_argument(config.RUNTIME_EXECUTABLE),
-                 string_to_argument(sequential_script_file_name),
-                 string_to_argument(ir_filename)]
+def make_call_to_spec_runtime() -> AstNode:
+    ## TODO: Call the runtime
+    # arguments = [string_to_argument("source"),
+    #              string_to_argument(config.RUNTIME_EXECUTABLE),
+    #              string_to_argument(sequential_script_file_name),
+    #              string_to_argument(ir_filename)]
+    arguments = [string_to_argument("echo"),
+                 string_to_argument("No speculative runtime component yet!")]
     ## Pass a relevant argument to the planner
     runtime_node = make_command(arguments)
     return runtime_node

--- a/compiler/shell_ast/ast_to_ast.py
+++ b/compiler/shell_ast/ast_to_ast.py
@@ -16,7 +16,7 @@ class TransformationType(Enum):
 ## trasnformation.
 class TransformationOptions:
     def __init__(self, args):
-        self.mode = TransformationType(args.mode)
+        self.mode = TransformationType(args.preprocess_mode)
         if self.mode is TransformationType.SPECULATIVE:
             self.partial_order_file = args.partial_order_file
     

--- a/compiler/util_spec.py
+++ b/compiler/util_spec.py
@@ -1,0 +1,9 @@
+
+##
+## This file contains utility functions useful for the speculative execution component
+##
+
+def initialize_po_file(trans_options) -> None:
+    ## Initializae the partial order file
+    open(trans_options.get_partial_order_file(), 'w').close()
+


### PR DESCRIPTION
Use by running the following when on `$PASH_TOP`.

```sh
./compiler/preprocessor/preprocessor spec input.sh partial_order.sh
```

It will save a sequence of commands in `partial_order.sh.`

For now it is very janky since it prints each command in its own line (but this can fail very badly if commands contain newlines).

TODO: We need to fix this to print each command in its own file, and the partial order file should only contain the ids of the commands and their ordering. I need to add a new directory `speculation` in compiler, that will contain relevant code.