### PR TITLE
Add df regions to their own files and only edges to the po file

### DIFF
--- a/compiler/preprocessor/preprocessor.py
+++ b/compiler/preprocessor/preprocessor.py
@@ -7,7 +7,7 @@ from shell_ast import ast_to_ast
 from ir import FileIdGen
 from parse import parse_shell_to_asts, from_ast_objects_to_shell
 from util import *
-from util_spec import *
+from speculative import util_spec
 
 LOGGING_PREFIX = "PaSh Preprocessor: "
 
@@ -39,7 +39,7 @@ def preprocess_asts(ast_objects, args):
     trans_options = ast_to_ast.TransformationOptions(args)
 
     if trans_options.get_mode() is ast_to_ast.TransformationType.SPECULATIVE:
-        initialize_po_file(trans_options)
+        util_spec.initialize(trans_options)
 
     ## Preprocess ASTs by replacing AST regions with calls to PaSh's runtime.
     ## Then the runtime will do the compilation and optimization with additional

--- a/compiler/speculative/util_spec.py
+++ b/compiler/speculative/util_spec.py
@@ -1,0 +1,60 @@
+
+import os
+import config
+
+##
+## This file contains utility functions useful for the speculative execution component
+##
+
+## TODO: There is a similar class in ir.py. Could we avoid duplication?
+class IdGen:
+    def __init__(self, counter=0):
+        self.counter = counter
+    
+    def get_next_id(self):
+        new_id = self.counter
+        self.counter += 1
+        return new_id
+
+## TODO: Should we move this to the trans_options class 
+##       (which we could rename to trans_config) and make a subclass for
+##       the two different transformations.
+ID_GENERATOR = IdGen()
+
+def initialize(trans_options) -> None:
+    ## Make the directory that contains the files in the partial order
+    dir_path = partial_order_directory()
+    os.makedirs(dir_path)
+    ## Initialize the po file
+    initialize_po_file(trans_options, dir_path)
+
+def partial_order_directory() -> str:
+    return f'{config.PASH_TMP_PREFIX}/speculative/partial_order/'
+
+
+def initialize_po_file(trans_options, dir_path) -> None:
+    ## Initializae the partial order file
+    with open(trans_options.get_partial_order_file(), 'w') as f:
+        f.write(f'# Partial order files path:\n')
+        f.write(f'{dir_path}\n')
+
+def get_next_id():
+    global ID_GENERATOR
+    return ID_GENERATOR.get_next_id()
+
+## TODO: To support partial orders, we need to pass some more context here,
+##       i.e., the connections of this node. Now it assumes we have a sequence.
+def save_df_region(text_to_output: str, trans_options, df_region_id: int, predecessor_ids: int) -> None:
+    # Save df_region as text in its own file
+    df_region_path = f'{partial_order_directory()}/{df_region_id}'
+    with open(df_region_path, "w") as f:
+        f.write(text_to_output)
+
+    # Save the edges in the partial order file
+    partial_order_file_path = trans_options.get_partial_order_file()
+    with open(partial_order_file_path, "a") as po_file:
+        for predecessor in predecessor_ids:
+            po_file.write(serialize_edge(predecessor, df_region_id))
+
+def serialize_edge(from_id, to_id):
+    return f'{from_id} -> {to_id}\n'

--- a/compiler/util_spec.py
+++ b/compiler/util_spec.py
@@ -1,9 +1,0 @@
-
-##
-## This file contains utility functions useful for the speculative execution component
-##
-
-def initialize_po_file(trans_options) -> None:
-    ## Initializae the partial order file
-    open(trans_options.get_partial_order_file(), 'w').close()
-


### PR DESCRIPTION
Properly serialize the different df regions when spec preprocessing and only add the edges to the po file.

Use by running the following when in `$PASH_TOP`.
```sh
./compiler/preprocessor/preprocessor spec input.sh partial_order.txt
```

The `partial_order.txt` file will look like this:
```sh
# Partial order files path:
/tmp/pash_BYmDfbB//speculative/partial_order/
0 -> 1
...
```
where the path is the directory that stores different df regions. For example, region `0` is stored in `/tmp/pash_BYmDfbB//speculative/partial_order/0` for that particular example. Furthermore, the arrows show the partial order of df_regions in the original file (for now it is always a sequence, but it can be extended to be a partial order.

TODO: The next step is to add a proper entry point in PaSh that will wait for the scheduler at each runtime invocation. The new entry point should be invoked by a wrapper around PaSh that will first run the scheduler and initialize some environment variables, and then call PaSh.