### PR TITLE
Clean up shell AST

### DIFF
--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -40,8 +40,6 @@ compile_cases = {
                      lambda ast_node: compile_node_redir_subshell(ast_node, fileIdGen, config)),
         "Background": (lambda fileIdGen, config:
                        lambda ast_node: compile_node_background(ast_node, fileIdGen, config)),
-        "Defun": (lambda fileIdGen, config:
-                  lambda ast_node: compile_node_defun(ast_node, fileIdGen, config)),
         "For": (lambda fileIdGen, config:
                   lambda ast_node: compile_node_for(ast_node, fileIdGen, config))
         }
@@ -215,21 +213,6 @@ def compile_node_background(ast_node, fileIdGen, config):
         compiled_ast.node = compiled_node
 
     return compiled_ast
-
-## TODO: Is this code ever called? I don't think so!
-def compile_node_defun(ast_node, fileIdGen, config):
-    ## It is not clear how we should handle functions.
-    ##
-    ## - Should we transform their body to IR?
-    ## - Should we handle calls to the functions as commands?
-    ##
-    ## It seems that we should do both. But we have to think if
-    ## this introduces any possible problem.
-
-    ## TODO: Investigate whether it is fine to just compile the
-    ##       body of functions.
-    compiled_body = compile_node(ast_node.body, fileIdGen, config)
-    return make_kv(construct, [ast_node.line_number, ast_node.name, compiled_body])
 
 def compile_node_for(ast_node, fileIdGen, config):
     ## TODO: Investigate what kind of check could we do to make a for

--- a/compiler/ast_to_ir.py
+++ b/compiler/ast_to_ir.py
@@ -47,12 +47,17 @@ compile_cases = {
         }
 
 
-def compile_asts(ast_objects, fileIdGen, config):
+def compile_asts(ast_objects: "list[AstNode]", fileIdGen, config):
     compiled_asts = []
     acc_ir = None
     for i, ast_object in enumerate(ast_objects):
         # log("Compiling AST {}".format(i))
         # log(ast_object)
+        ## TODO: Move this outside this function
+        # assert(not isinstance(untyped_ast_object, AstNode))
+        # ast_object = to_ast_node(untyped_ast_object)
+
+        assert(isinstance(ast_object, AstNode))
 
         ## Compile subtrees of the AST to out intermediate representation
         expanded_ast = expand_command(ast_object, config)

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -5,6 +5,7 @@ import sys
 
 from shell_ast.ast_util import UnparsedScript
 from shell_ast.ast_node import AstNode, ast_node_to_untyped_deep
+from shell_ast.untyped_to_ast import to_ast_node
 
 from util import *
 
@@ -16,7 +17,14 @@ import libdash.printer
 def parse_shell_to_asts(input_script_path):
     try:
         new_ast_objects = libdash.parser.parse(input_script_path)
-        return list(new_ast_objects)
+
+        ## Transform the untyped ast objects to typed ones
+        typed_ast_objects = []
+        for untyped_ast, original_text, linno_before, linno_after, in new_ast_objects:
+             typed_ast = to_ast_node(untyped_ast)
+             typed_ast_objects.append((typed_ast, original_text, linno_before, linno_after))
+
+        return typed_ast_objects
     except libdash.parser.ParsingException as e:
         log("Parsing error!", e)
         sys.exit(1)

--- a/compiler/preprocessor/preprocessor.py
+++ b/compiler/preprocessor/preprocessor.py
@@ -4,6 +4,7 @@ import os
 
 import config
 from shell_ast import ast_to_ast
+from shell_ast.ast_node import AstNode
 from ir import FileIdGen
 from parse import parse_shell_to_asts, from_ast_objects_to_shell
 from util import *

--- a/compiler/shell_ast/ast_node.py
+++ b/compiler/shell_ast/ast_node.py
@@ -7,146 +7,6 @@ from util import *
 
 class AstNode:
     NodeName = 'None'
-    # create an AstNode object from an ast object as parsed by libdash
-    # def __init__(self, ast_object):
-    #     try:
-    #         self.construct = AstNodeConstructor(ast_object[0])
-    #         self.parse_args(ast_object[1])
-    #     except ValueError as no_matching_construct:
-    #         raise NoMatchException('{} is not a construct we can handle'.format(ast_object[0]))
-
-    # def parse_args(self, args):
-    #     if self.construct is AstNodeConstructor.PIPE:
-    #         self.is_background = args[0]
-    #         self.items = args[1]
-    #     elif self.construct is AstNodeConstructor.COMMAND:
-    #         self.line_number = args[0]
-    #         self.assignments = args[1]
-    #         self.arguments = args[2]
-    #         self.redir_list = args[3]
-    #     elif self.construct is AstNodeConstructor.SUBSHELL:
-    #         self.line_number = args[0]
-    #         self.body = args[1]
-    #         self.redir_list = args[2]
-    #     elif self.construct in [AstNodeConstructor.AND, AstNodeConstructor.OR, AstNodeConstructor.SEMI]:
-    #         self.left_operand = args[0]
-    #         self.right_operand = args[1]
-    #     elif self.construct is AstNodeConstructor.NOT:
-    #         self.body = args
-    #     elif self.construct in [AstNodeConstructor.REDIR, AstNodeConstructor.BACKGROUND]:
-    #         self.line_number = args[0]
-    #         # TODO maybe pick a better name?
-    #         self.node = args[1]
-    #         self.redir_list = args[2]
-    #     elif self.construct is AstNodeConstructor.DEFUN:
-    #         self.line_number = args[0]
-    #         self.name = args[1]
-    #         self.body = args[2]
-    #     elif self.construct is AstNodeConstructor.FOR:
-    #         self.line_number = args[0]
-    #         self.argument = args[1]
-    #         self.body = args[2]
-    #         self.variable = args[3]
-    #     elif self.construct is AstNodeConstructor.WHILE:
-    #         self.test = args[0]
-    #         self.body = args[1]
-    #     elif self.construct is AstNodeConstructor.IF:
-    #         self.cond = args[0]
-    #         self.then_b = args[1]
-    #         self.else_b = args[2]
-    #     elif self.construct is AstNodeConstructor.CASE:
-    #         self.line_number = args[0]
-    #         self.argument = args[1]
-    #         self.cases = args[2]
-    #     else:
-    #         raise ValueError()
-    
-    # def __repr__(self):
-    #     if self.construct is AstNodeConstructor.FOR:
-    #         output = "for {} in {}; do ({})".format(self.variable, self.argument, self.body)
-    #         return output
-    #     log(self.construct)
-    #     return NotImplemented 
-
-    # def check(self, **kwargs):
-    #     # user-supplied custom checks
-    #     for key, value in kwargs.items():
-    #         try:
-    #             assert(value())
-    #         except Exception as exc:
-    #             log("check for {} construct failed at key {}".format(self.construct, key))
-    #             raise exc
-    
-    # def json_serialize(self):
-    #     if self.construct is AstNodeConstructor.FOR:
-    #         json_output = make_kv(self.construct.value,
-    #                        [self.line_number,
-    #                         self.argument,
-    #                         self.body,
-    #                         self.variable])
-    #     elif self.construct is AstNodeConstructor.WHILE:
-    #         json_output = make_kv(self.construct.value,
-    #                        [self.test,
-    #                         self.body])
-    #     # elif self.construct is AstNodeConstructor.COMMAND:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.line_number,
-    #     #                            self.assignments,
-    #     #                            self.arguments,
-    #     #                            self.redir_list])
-    #     # elif self.construct is AstNodeConstructor.REDIR:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.line_number,
-    #     #                            self.node,
-    #     #                            self.redir_list])
-    #     # elif self.construct is AstNodeConstructor.BACKGROUND:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.line_number,
-    #     #                            self.node,
-    #     #                            self.redir_list])
-    #     # elif self.construct is AstNodeConstructor.SUBSHELL:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.line_number,
-    #     #                            self.body,
-    #     #                            self.redir_list])
-    #     # elif self.construct is AstNodeConstructor.PIPE:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.is_background,
-    #     #                            self.items])
-    #     # elif self.construct is AstNodeConstructor.DEFUN:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.line_number,
-    #     #                            self.name,
-    #     #                            self.body])
-    #     # elif self.construct is AstNodeConstructor.IF:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.cond,
-    #     #                            self.then_b,
-    #     #                            self.else_b])
-    #     # elif self.construct is AstNodeConstructor.SEMI:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.left_operand,
-    #     #                            self.right_operand])
-    #     # elif self.construct is AstNodeConstructor.OR:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.left_operand,
-    #     #                            self.right_operand])
-    #     # elif self.construct is AstNodeConstructor.AND:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.left_operand,
-    #     #                            self.right_operand])
-    #     # elif self.construct is AstNodeConstructor.NOT:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           self.body)
-    #     # elif self.construct is AstNodeConstructor.CASE:
-    #     #     json_output = make_kv(self.construct.value,
-    #     #                           [self.line_number,
-    #     #                            self.argument,
-    #     #                            self.cases])
-    #     else:
-    #         log("Not implemented serialization", self)
-    #         json_output = NotImplemented
-    #     return json_output
 
 class CustomJSONEncoder(JSONEncoder):
     def default(self, obj):
@@ -155,14 +15,11 @@ class CustomJSONEncoder(JSONEncoder):
         # Let the base class default method raise the TypeError
         return JSONEncoder.default(self, obj)
 
-## TODO: Move serialize and repr to the subclasses below
-
-## TODO: Determine all field types
 
 class PipeNode(AstNode):
     NodeName = 'Pipe'
     is_background: bool
-    items: object ## TODO: Find type
+    items: "list[AstNode]"
 
     def __init__(self, is_background, items):
         self.is_background = is_background
@@ -183,9 +40,9 @@ class PipeNode(AstNode):
 class CommandNode(AstNode):
     NodeName = 'Command'
     line_number: int
-    assignments: object
-    arguments: object
-    redir_list: object
+    assignments: list
+    arguments: list
+    redir_list: list
 
     def __init__(self, line_number, assignments, arguments, redir_list):
         self.line_number = line_number
@@ -213,7 +70,7 @@ class SubshellNode(AstNode):
     NodeName = 'Subshell'
     line_number: int
     body: AstNode
-    redir_list: object
+    redir_list: list
 
     def __init__(self, line_number, body, redir_list):
         self.line_number = line_number
@@ -301,7 +158,7 @@ class RedirNode(AstNode):
     NodeName = 'Redir'
     line_number: int
     node: AstNode
-    redir_list: object
+    redir_list: list
 
     def __init__(self, line_number, node, redir_list):
         self.line_number = line_number
@@ -319,7 +176,7 @@ class BackgroundNode(AstNode):
     NodeName = 'Background'
     line_number: int
     node: AstNode
-    redir_list: object
+    redir_list: list
 
     def __init__(self, line_number, node, redir_list):
         self.line_number = line_number
@@ -378,7 +235,7 @@ class ForNode(AstNode):
 
 class WhileNode(AstNode):
     NodeName = 'While'
-    test: object
+    test: AstNode
     body: AstNode
 
     def __init__(self, test, body):
@@ -393,7 +250,7 @@ class WhileNode(AstNode):
 
 class IfNode(AstNode):
     NodeName = 'If'
-    cond: object
+    cond: AstNode
     then_b: AstNode
     else_b: AstNode
 
@@ -413,7 +270,7 @@ class CaseNode(AstNode):
     NodeName = 'Case'
     line_number: int
     argument: object
-    cases: object
+    cases: list
 
     def __init__(self, line_number, argument, cases):
         self.line_number = line_number

--- a/compiler/shell_ast/ast_node.py
+++ b/compiler/shell_ast/ast_node.py
@@ -451,3 +451,16 @@ def ast_node_to_untyped_deep(node):
         return {k: ast_node_to_untyped_deep(v) for k, v in node.items()}
     else:
         return node
+
+def make_typed_semi_sequence(asts: "list[AstNode]") -> SemiNode:
+    assert(len(asts) > 0)
+
+    if(len(asts) == 1):
+        return asts[0]
+    else:
+        acc = asts[-1]
+        ## Remove the last ast
+        iter_asts = asts[:-1]
+        for ast in iter_asts[::-1]:
+            acc = SemiNode(ast, acc)
+        return acc

--- a/compiler/shell_ast/ast_node.py
+++ b/compiler/shell_ast/ast_node.py
@@ -68,14 +68,14 @@ class AstNode:
     #     log(self.construct)
     #     return NotImplemented 
 
-    def check(self, **kwargs):
-        # user-supplied custom checks
-        for key, value in kwargs.items():
-            try:
-                assert(value())
-            except Exception as exc:
-                log("check for {} construct failed at key {}".format(self.construct, key))
-                raise exc
+    # def check(self, **kwargs):
+    #     # user-supplied custom checks
+    #     for key, value in kwargs.items():
+    #         try:
+    #             assert(value())
+    #         except Exception as exc:
+    #             log("check for {} construct failed at key {}".format(self.construct, key))
+    #             raise exc
     
     # def json_serialize(self):
     #     if self.construct is AstNodeConstructor.FOR:

--- a/compiler/shell_ast/ast_node.py
+++ b/compiler/shell_ast/ast_node.py
@@ -5,89 +5,68 @@ from definitions.no_match_exception import *
 from util import *
 
 
-## TODO: Create subclasses for all different types of AstNodes
 class AstNode:
+    NodeName = 'None'
     # create an AstNode object from an ast object as parsed by libdash
-    def __init__(self, ast_object):
-        try:
-            self.construct = AstNodeConstructor(ast_object[0])
-            self.parse_args(ast_object[1])
-        except ValueError as no_matching_construct:
-            raise NoMatchException('{} is not a construct we can handle'.format(ast_object[0]))
+    # def __init__(self, ast_object):
+    #     try:
+    #         self.construct = AstNodeConstructor(ast_object[0])
+    #         self.parse_args(ast_object[1])
+    #     except ValueError as no_matching_construct:
+    #         raise NoMatchException('{} is not a construct we can handle'.format(ast_object[0]))
 
-    def parse_args(self, args):
-        if self.construct is AstNodeConstructor.PIPE:
-            self.is_background = args[0]
-            self.items = args[1]
-        elif self.construct is AstNodeConstructor.COMMAND:
-            self.line_number = args[0]
-            self.assignments = args[1]
-            self.arguments = args[2]
-            self.redir_list = args[3]
-        elif self.construct is AstNodeConstructor.SUBSHELL:
-            self.line_number = args[0]
-            self.body = args[1]
-            self.redir_list = args[2]
-        elif self.construct in [AstNodeConstructor.AND, AstNodeConstructor.OR, AstNodeConstructor.SEMI]:
-            self.left_operand = args[0]
-            self.right_operand = args[1]
-        elif self.construct is AstNodeConstructor.NOT:
-            self.body = args
-        elif self.construct in [AstNodeConstructor.REDIR, AstNodeConstructor.BACKGROUND]:
-            self.line_number = args[0]
-            # TODO maybe pick a better name?
-            self.node = args[1]
-            self.redir_list = args[2]
-        elif self.construct is AstNodeConstructor.DEFUN:
-            self.line_number = args[0]
-            self.name = args[1]
-            self.body = args[2]
-        elif self.construct is AstNodeConstructor.FOR:
-            self.line_number = args[0]
-            self.argument = args[1]
-            self.body = args[2]
-            self.variable = args[3]
-        elif self.construct is AstNodeConstructor.WHILE:
-            self.test = args[0]
-            self.body = args[1]
-        elif self.construct is AstNodeConstructor.IF:
-            self.cond = args[0]
-            self.then_b = args[1]
-            self.else_b = args[2]
-        elif self.construct is AstNodeConstructor.CASE:
-            self.line_number = args[0]
-            self.argument = args[1]
-            self.cases = args[2]
-        else:
-            raise ValueError()
+    # def parse_args(self, args):
+    #     if self.construct is AstNodeConstructor.PIPE:
+    #         self.is_background = args[0]
+    #         self.items = args[1]
+    #     elif self.construct is AstNodeConstructor.COMMAND:
+    #         self.line_number = args[0]
+    #         self.assignments = args[1]
+    #         self.arguments = args[2]
+    #         self.redir_list = args[3]
+    #     elif self.construct is AstNodeConstructor.SUBSHELL:
+    #         self.line_number = args[0]
+    #         self.body = args[1]
+    #         self.redir_list = args[2]
+    #     elif self.construct in [AstNodeConstructor.AND, AstNodeConstructor.OR, AstNodeConstructor.SEMI]:
+    #         self.left_operand = args[0]
+    #         self.right_operand = args[1]
+    #     elif self.construct is AstNodeConstructor.NOT:
+    #         self.body = args
+    #     elif self.construct in [AstNodeConstructor.REDIR, AstNodeConstructor.BACKGROUND]:
+    #         self.line_number = args[0]
+    #         # TODO maybe pick a better name?
+    #         self.node = args[1]
+    #         self.redir_list = args[2]
+    #     elif self.construct is AstNodeConstructor.DEFUN:
+    #         self.line_number = args[0]
+    #         self.name = args[1]
+    #         self.body = args[2]
+    #     elif self.construct is AstNodeConstructor.FOR:
+    #         self.line_number = args[0]
+    #         self.argument = args[1]
+    #         self.body = args[2]
+    #         self.variable = args[3]
+    #     elif self.construct is AstNodeConstructor.WHILE:
+    #         self.test = args[0]
+    #         self.body = args[1]
+    #     elif self.construct is AstNodeConstructor.IF:
+    #         self.cond = args[0]
+    #         self.then_b = args[1]
+    #         self.else_b = args[2]
+    #     elif self.construct is AstNodeConstructor.CASE:
+    #         self.line_number = args[0]
+    #         self.argument = args[1]
+    #         self.cases = args[2]
+    #     else:
+    #         raise ValueError()
     
-    def __repr__(self):
-        if self.construct is AstNodeConstructor.PIPE:
-            if (self.is_background):
-                return "Background Pipe: {}".format(self.items)    
-            else:
-                return "Pipe: {}".format(self.items)
-        elif self.construct is AstNodeConstructor.COMMAND:
-            output = "Command: {}".format(self.arguments)
-            if(len(self.assignments) > 0):
-                output += ", ass[{}]".format(self.assignments)
-            if(len(self.redir_list) > 0):
-                output += ", reds[{}]".format(self.redir_list)
-            return output
-        elif self.construct is AstNodeConstructor.FOR:
-            output = "for {} in {}; do ({})".format(self.variable, self.argument, self.body)
-            return output
-        elif self.construct is AstNodeConstructor.AND:
-            output = "{} && {}".format(self.left_operand, self.right_operand)
-            return output
-        elif self.construct is AstNodeConstructor.SEMI:
-            output = "{} ; {}".format(self.left_operand, self.right_operand)
-            return output
-        elif self.construct is AstNodeConstructor.OR:
-            output = "{} || {}".format(self.left_operand, self.right_operand)
-            return output
-        log(self.construct)
-        return NotImplemented 
+    # def __repr__(self):
+    #     if self.construct is AstNodeConstructor.FOR:
+    #         output = "for {} in {}; do ({})".format(self.variable, self.argument, self.body)
+    #         return output
+    #     log(self.construct)
+    #     return NotImplemented 
 
     def check(self, **kwargs):
         # user-supplied custom checks
@@ -98,76 +77,76 @@ class AstNode:
                 log("check for {} construct failed at key {}".format(self.construct, key))
                 raise exc
     
-    def json_serialize(self):
-        if self.construct is AstNodeConstructor.FOR:
-            json_output = make_kv(self.construct.value,
-                           [self.line_number,
-                            self.argument,
-                            self.body,
-                            self.variable])
-        elif self.construct is AstNodeConstructor.WHILE:
-            json_output = make_kv(self.construct.value,
-                           [self.test,
-                            self.body])
-        elif self.construct is AstNodeConstructor.COMMAND:
-            json_output = make_kv(self.construct.value,
-                                  [self.line_number,
-                                   self.assignments,
-                                   self.arguments,
-                                   self.redir_list])
-        elif self.construct is AstNodeConstructor.REDIR:
-            json_output = make_kv(self.construct.value,
-                                  [self.line_number,
-                                   self.node,
-                                   self.redir_list])
-        elif self.construct is AstNodeConstructor.BACKGROUND:
-            json_output = make_kv(self.construct.value,
-                                  [self.line_number,
-                                   self.node,
-                                   self.redir_list])
-        elif self.construct is AstNodeConstructor.SUBSHELL:
-            json_output = make_kv(self.construct.value,
-                                  [self.line_number,
-                                   self.body,
-                                   self.redir_list])
-        elif self.construct is AstNodeConstructor.PIPE:
-            json_output = make_kv(self.construct.value,
-                                  [self.is_background,
-                                   self.items])
-        elif self.construct is AstNodeConstructor.DEFUN:
-            json_output = make_kv(self.construct.value,
-                                  [self.line_number,
-                                   self.name,
-                                   self.body])
-        elif self.construct is AstNodeConstructor.IF:
-            json_output = make_kv(self.construct.value,
-                                  [self.cond,
-                                   self.then_b,
-                                   self.else_b])
-        elif self.construct is AstNodeConstructor.SEMI:
-            json_output = make_kv(self.construct.value,
-                                  [self.left_operand,
-                                   self.right_operand])
-        elif self.construct is AstNodeConstructor.OR:
-            json_output = make_kv(self.construct.value,
-                                  [self.left_operand,
-                                   self.right_operand])
-        elif self.construct is AstNodeConstructor.AND:
-            json_output = make_kv(self.construct.value,
-                                  [self.left_operand,
-                                   self.right_operand])
-        elif self.construct is AstNodeConstructor.NOT:
-            json_output = make_kv(self.construct.value,
-                                  self.body)
-        elif self.construct is AstNodeConstructor.CASE:
-            json_output = make_kv(self.construct.value,
-                                  [self.line_number,
-                                   self.argument,
-                                   self.cases])
-        else:
-            log("Not implemented serialization", self)
-            json_output = NotImplemented
-        return json_output
+    # def json_serialize(self):
+    #     if self.construct is AstNodeConstructor.FOR:
+    #         json_output = make_kv(self.construct.value,
+    #                        [self.line_number,
+    #                         self.argument,
+    #                         self.body,
+    #                         self.variable])
+    #     elif self.construct is AstNodeConstructor.WHILE:
+    #         json_output = make_kv(self.construct.value,
+    #                        [self.test,
+    #                         self.body])
+    #     # elif self.construct is AstNodeConstructor.COMMAND:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.line_number,
+    #     #                            self.assignments,
+    #     #                            self.arguments,
+    #     #                            self.redir_list])
+    #     # elif self.construct is AstNodeConstructor.REDIR:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.line_number,
+    #     #                            self.node,
+    #     #                            self.redir_list])
+    #     # elif self.construct is AstNodeConstructor.BACKGROUND:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.line_number,
+    #     #                            self.node,
+    #     #                            self.redir_list])
+    #     # elif self.construct is AstNodeConstructor.SUBSHELL:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.line_number,
+    #     #                            self.body,
+    #     #                            self.redir_list])
+    #     # elif self.construct is AstNodeConstructor.PIPE:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.is_background,
+    #     #                            self.items])
+    #     # elif self.construct is AstNodeConstructor.DEFUN:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.line_number,
+    #     #                            self.name,
+    #     #                            self.body])
+    #     # elif self.construct is AstNodeConstructor.IF:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.cond,
+    #     #                            self.then_b,
+    #     #                            self.else_b])
+    #     # elif self.construct is AstNodeConstructor.SEMI:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.left_operand,
+    #     #                            self.right_operand])
+    #     # elif self.construct is AstNodeConstructor.OR:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.left_operand,
+    #     #                            self.right_operand])
+    #     # elif self.construct is AstNodeConstructor.AND:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.left_operand,
+    #     #                            self.right_operand])
+    #     # elif self.construct is AstNodeConstructor.NOT:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           self.body)
+    #     # elif self.construct is AstNodeConstructor.CASE:
+    #     #     json_output = make_kv(self.construct.value,
+    #     #                           [self.line_number,
+    #     #                            self.argument,
+    #     #                            self.cases])
+    #     else:
+    #         log("Not implemented serialization", self)
+    #         json_output = NotImplemented
+    #     return json_output
 
 class CustomJSONEncoder(JSONEncoder):
     def default(self, obj):
@@ -176,7 +155,278 @@ class CustomJSONEncoder(JSONEncoder):
         # Let the base class default method raise the TypeError
         return JSONEncoder.default(self, obj)
 
+## TODO: Move serialize and repr to the subclasses below
 
+## TODO: Determine all field types
+
+class PipeNode(AstNode):
+    NodeName = 'Pipe'
+    is_background: bool
+    items: object ## TODO: Find type
+
+    def __init__(self, is_background, items):
+        self.is_background = is_background
+        self.items = items
+
+    def __repr__(self):
+        if (self.is_background):
+            return "Background Pipe: {}".format(self.items)    
+        else:
+            return "Pipe: {}".format(self.items)
+        
+    def json_serialize(self):
+        json_output = make_kv(PipeNode.NodeName,
+                              [self.is_background,
+                               self.items])
+        return json_output
+
+class CommandNode(AstNode):
+    NodeName = 'Command'
+    line_number: int
+    assignments: object
+    arguments: object
+    redir_list: object
+
+    def __init__(self, line_number, assignments, arguments, redir_list):
+        self.line_number = line_number
+        self.assignments = assignments
+        self.arguments = arguments
+        self.redir_list = redir_list
+
+    def __repr__(self):
+        output = "Command: {}".format(self.arguments)
+        if(len(self.assignments) > 0):
+            output += ", ass[{}]".format(self.assignments)
+        if(len(self.redir_list) > 0):
+            output += ", reds[{}]".format(self.redir_list)
+        return output
+
+    def json_serialize(self):
+        json_output = make_kv(CommandNode.NodeName,
+                              [self.line_number,
+                               self.assignments,
+                               self.arguments,
+                               self.redir_list])
+        return json_output
+
+class SubshellNode(AstNode):
+    NodeName = 'Subshell'
+    line_number: int
+    body: AstNode
+    redir_list: object
+
+    def __init__(self, line_number, body, redir_list):
+        self.line_number = line_number
+        self.body = body
+        self.redir_list = redir_list
+
+    def json_serialize(self):
+        json_output = make_kv(SubshellNode.NodeName,
+                              [self.line_number,
+                               self.body,
+                               self.redir_list])
+        return json_output
+        
+class AndNode(AstNode):
+    NodeName = 'And'
+    left_operand: AstNode
+    right_operand: AstNode
+
+    def __init__(self, left_operand, right_operand):
+        self.left_operand = left_operand
+        self.right_operand = right_operand
+
+    def __repr__(self):
+        output = "{} && {}".format(self.left_operand, self.right_operand)
+        return output
+    
+    def json_serialize(self):
+        json_output = make_kv(AndNode.NodeName,
+                              [self.left_operand,
+                               self.right_operand])
+        return json_output
+
+class OrNode(AstNode):
+    NodeName = 'Or'
+    left_operand: AstNode
+    right_operand: AstNode
+
+    def __init__(self, left_operand, right_operand):
+        self.left_operand = left_operand
+        self.right_operand = right_operand
+
+    def __repr__(self):
+        output = "{} || {}".format(self.left_operand, self.right_operand)
+        return output
+    
+    def json_serialize(self):
+        json_output = make_kv(OrNode.NodeName,
+                              [self.left_operand,
+                               self.right_operand])
+        return json_output
+    
+class SemiNode(AstNode):
+    NodeName = 'Semi'
+    left_operand: AstNode
+    right_operand: AstNode
+
+    def __init__(self, left_operand, right_operand):
+        self.left_operand = left_operand
+        self.right_operand = right_operand
+
+    def __repr__(self):
+        output = "{} ; {}".format(self.left_operand, self.right_operand)
+        return output
+    
+    def json_serialize(self):
+        json_output = make_kv(SemiNode.NodeName,
+                              [self.left_operand,
+                               self.right_operand])
+        return json_output
+
+
+class NotNode(AstNode):
+    NodeName = 'Not'
+    body: AstNode
+
+    def __init__(self, body):
+        self.body = body
+
+    def json_serialize(self):
+        json_output = make_kv(NotNode.NodeName,
+                              self.body)
+        return json_output
+
+class RedirNode(AstNode):
+    NodeName = 'Redir'
+    line_number: int
+    node: AstNode
+    redir_list: object
+
+    def __init__(self, line_number, node, redir_list):
+        self.line_number = line_number
+        self.node = node
+        self.redir_list = redir_list
+
+    def json_serialize(self):
+        json_output = make_kv(RedirNode.NodeName,
+                              [self.line_number,
+                               self.node,
+                               self.redir_list])
+        return json_output
+
+class BackgroundNode(AstNode):
+    NodeName = 'Background'
+    line_number: int
+    node: AstNode
+    redir_list: object
+
+    def __init__(self, line_number, node, redir_list):
+        self.line_number = line_number
+        self.node = node
+        self.redir_list = redir_list
+
+    def json_serialize(self):
+        json_output = make_kv(BackgroundNode.NodeName,
+                              [self.line_number,
+                               self.node,
+                               self.redir_list])
+        return json_output
+
+class DefunNode(AstNode):
+    NodeName = 'Defun'
+    line_number: int
+    name: object
+    body: AstNode
+
+    def __init__(self, line_number, name, body):
+        self.line_number = line_number
+        self.name = name
+        self.body = body
+
+    def json_serialize(self):
+        json_output = make_kv(DefunNode.NodeName,
+                              [self.line_number,
+                               self.name,
+                               self.body])
+        return json_output
+
+class ForNode(AstNode):
+    NodeName = 'For'
+    line_number: int
+    argument: object
+    body: AstNode
+    variable: object
+
+    def __init__(self, line_number, argument, body, variable):
+        self.line_number = line_number
+        self.argument = argument
+        self.body = body
+        self.variable = variable
+
+    def __repr__(self):
+        output = "for {} in {}; do ({})".format(self.variable, self.argument, self.body)
+        return output
+    
+    def json_serialize(self):
+        json_output = make_kv(ForNode.NodeName,
+                              [self.line_number,
+                               self.argument,
+                               self.body,
+                               self.variable])
+        return json_output
+
+class WhileNode(AstNode):
+    NodeName = 'While'
+    test: object
+    body: AstNode
+
+    def __init__(self, test, body):
+        self.test = test
+        self.body = body
+
+    def json_serialize(self):
+        json_output = make_kv(WhileNode.NodeName,
+                              [self.test,
+                               self.body])
+        return json_output
+
+class IfNode(AstNode):
+    NodeName = 'If'
+    cond: object
+    then_b: AstNode
+    else_b: AstNode
+
+    def __init__(self, cond, then_b, else_b):
+        self.cond = cond
+        self.then_b = then_b
+        self.else_b = else_b
+
+    def json_serialize(self):
+        json_output = make_kv(IfNode.NodeName,
+                              [self.cond,
+                               self.then_b,
+                               self.else_b])
+        return json_output
+
+class CaseNode(AstNode):
+    NodeName = 'Case'
+    line_number: int
+    argument: object
+    cases: object
+
+    def __init__(self, line_number, argument, body):
+        self.line_number = line_number
+        self.argument = argument
+        self.body = body
+
+    def json_serialize(self):
+        json_output = make_kv(CaseNode.NodeName,
+                              [self.line_number,
+                               self.argument,
+                               self.cases])
+        return json_output
+    
 ## This function takes an object that contains a mix of untyped and typed AstNodes (yuck) 
 ## and turns it into untyped json-like object. It is required atm because the infrastructure that
 ## we have does not translate everything to its typed form at once before compiling, and therefore

--- a/compiler/shell_ast/ast_node.py
+++ b/compiler/shell_ast/ast_node.py
@@ -415,10 +415,10 @@ class CaseNode(AstNode):
     argument: object
     cases: object
 
-    def __init__(self, line_number, argument, body):
+    def __init__(self, line_number, argument, cases):
         self.line_number = line_number
         self.argument = argument
-        self.body = body
+        self.cases = cases
 
     def json_serialize(self):
         json_output = make_kv(CaseNode.NodeName,

--- a/compiler/shell_ast/ast_to_ast.py
+++ b/compiler/shell_ast/ast_to_ast.py
@@ -153,9 +153,8 @@ def replace_ast_regions(ast_objects, trans_options):
             # log("Last object")
             last_object = True
 
-        untyped_ast, original_text, _linno_before, _linno_after = ast_object
-        ## TODO: Move this outside of this function
-        ast = to_ast_node(untyped_ast)
+        ast, original_text, _linno_before, _linno_after = ast_object
+        assert(isinstance(ast, AstNode))
 
         ## Goals: This transformation can approximate in several directions.
         ##        1. Not replacing a candidate dataflow region.
@@ -548,10 +547,6 @@ def replace_df_region(asts, trans_options, disable_parallel_pipelines=False, ast
     transformation_mode = trans_options.get_mode()
     if transformation_mode is TransformationType.PASH:
         ir_filename = ptempfile()
-
-        log("Saving asts:")
-        log(type(asts))
-        log(asts)
 
         ## Serialize the node in a file
         with open(ir_filename, "wb") as ir_file:

--- a/compiler/shell_ast/ast_to_ast.py
+++ b/compiler/shell_ast/ast_to_ast.py
@@ -6,6 +6,7 @@ import config
 
 from env_var_names import *
 from shell_ast.ast_util import *
+from shell_ast.untyped_to_ast import *
 from parse import from_ast_objects_to_shell
 from speculative import util_spec
 
@@ -379,7 +380,7 @@ def preprocess_node_for(ast_node, trans_options, last_object=False):
 
     ## Prepend the export in front of the loop
     # new_node = ast_node
-    new_node = AstNode(make_semi_sequence([export_node, ast_node, reset_loop_iters_node]))
+    new_node = to_ast_node(make_semi_sequence([export_node, ast_node, reset_loop_iters_node]))
     # print(new_node)
 
     preprocessed_ast_object = PreprocessedAST(new_node,

--- a/compiler/shell_ast/ast_util.py
+++ b/compiler/shell_ast/ast_util.py
@@ -41,20 +41,20 @@ class UnparsedScript:
 def check_if_ast_is_supported(construct, arguments, **kwargs):
     return
 
-def ast_match_untyped(untyped_ast_object, cases, *args):
+# def ast_match_untyped(untyped_ast_object, cases, *args):
     ## TODO: This should construct the complete AstNode object (not just the surface level)
     ## TODO: Remove this and then at some point make real proper use of the AstNode
-    ast_node = to_ast_node(untyped_ast_object)
+    # ast_node = to_ast_node(untyped_ast_object)
     # if isinstance(ast_node) is PipeNode:
     #     ast_node.check(children_count = lambda : len(ast_node.items) >= 2)
-    return ast_match(ast_node, cases, *args)
+    # return ast_match(ast_node, cases, *args)
 
 def ast_match(ast_node, cases, *args):
     ## TODO: Remove that once `ast_match_untyped` is fixed to
     ##       construct the whole AstNode object.
     ## TODO: Delete this PLEASE!
-    if(not isinstance(ast_node, AstNode)):
-        return ast_match_untyped(ast_node, cases, *args)
+    # if(not isinstance(ast_node, AstNode)):
+    #     return ast_match_untyped(ast_node, cases, *args)
 
     # print(ast_node, type(ast_node), type(ast_node).NodeName)
     return cases[type(ast_node).NodeName](*args)(ast_node)

--- a/compiler/shell_ast/ast_util.py
+++ b/compiler/shell_ast/ast_util.py
@@ -1,6 +1,7 @@
 
 from env_var_names import *
 from shell_ast.ast_node import *
+from shell_ast.untyped_to_ast import *
 from util import *
 
 
@@ -43,18 +44,20 @@ def check_if_ast_is_supported(construct, arguments, **kwargs):
 def ast_match_untyped(untyped_ast_object, cases, *args):
     ## TODO: This should construct the complete AstNode object (not just the surface level)
     ## TODO: Remove this and then at some point make real proper use of the AstNode
-    ast_node = AstNode(untyped_ast_object)
-    if ast_node.construct is AstNodeConstructor.PIPE:
-        ast_node.check(children_count = lambda : len(ast_node.items) >= 2)
+    ast_node = to_ast_node(untyped_ast_object)
+    # if isinstance(ast_node) is PipeNode:
+    #     ast_node.check(children_count = lambda : len(ast_node.items) >= 2)
     return ast_match(ast_node, cases, *args)
 
 def ast_match(ast_node, cases, *args):
     ## TODO: Remove that once `ast_match_untyped` is fixed to
     ##       construct the whole AstNode object.
+    ## TODO: Delete this PLEASE!
     if(not isinstance(ast_node, AstNode)):
         return ast_match_untyped(ast_node, cases, *args)
 
-    return cases[ast_node.construct.value](*args)(ast_node)
+    # print(ast_node, type(ast_node), type(ast_node).NodeName)
+    return cases[type(ast_node).NodeName](*args)(ast_node)
 
 
 

--- a/compiler/shell_ast/ast_util.py
+++ b/compiler/shell_ast/ast_util.py
@@ -41,25 +41,9 @@ class UnparsedScript:
 def check_if_ast_is_supported(construct, arguments, **kwargs):
     return
 
-# def ast_match_untyped(untyped_ast_object, cases, *args):
-    ## TODO: This should construct the complete AstNode object (not just the surface level)
-    ## TODO: Remove this and then at some point make real proper use of the AstNode
-    # ast_node = to_ast_node(untyped_ast_object)
-    # if isinstance(ast_node) is PipeNode:
-    #     ast_node.check(children_count = lambda : len(ast_node.items) >= 2)
-    # return ast_match(ast_node, cases, *args)
-
+## Implements a pattern-matching style traversal over the AST
 def ast_match(ast_node, cases, *args):
-    ## TODO: Remove that once `ast_match_untyped` is fixed to
-    ##       construct the whole AstNode object.
-    ## TODO: Delete this PLEASE!
-    # if(not isinstance(ast_node, AstNode)):
-    #     return ast_match_untyped(ast_node, cases, *args)
-
-    # print(ast_node, type(ast_node), type(ast_node).NodeName)
     return cases[type(ast_node).NodeName](*args)(ast_node)
-
-
 
 def format_args(args):
     formatted_args = [format_arg_chars(arg_chars) for arg_chars in args]

--- a/compiler/shell_ast/untyped_to_ast.py
+++ b/compiler/shell_ast/untyped_to_ast.py
@@ -1,7 +1,6 @@
 
 from shell_ast.ast_node import *
 
-## TODO: Recurse in necessary subfields and iterate deep
 def to_ast_node(obj) -> AstNode:
     k, v = obj
     if k == PipeNode.NodeName:

--- a/compiler/shell_ast/untyped_to_ast.py
+++ b/compiler/shell_ast/untyped_to_ast.py
@@ -6,55 +6,124 @@ def to_ast_node(obj) -> AstNode:
     k, v = obj
     if k == PipeNode.NodeName:
         node = PipeNode(is_background=v[0],
-                        items=v[1])
+                        items=to_ast_nodes(v[1]))
     elif k == CommandNode.NodeName:
         node = CommandNode(line_number=v[0],
-                           assignments=v[1],
-                           arguments=v[2],
-                           redir_list=v[3])
+                           assignments=to_assigns(v[1]),
+                           arguments=to_args(v[2]),
+                           redir_list=to_redirs(v[3]))
     elif k == SubshellNode.NodeName:
         node = SubshellNode(line_number=v[0],
-                            body=v[1],
-                            redir_list=v[2])
+                            body=to_ast_node(v[1]),
+                            redir_list=to_redirs(v[2]))
     elif k == AndNode.NodeName:
-        node = AndNode(left_operand=v[0],
-                        right_operand=v[1])
+        node = AndNode(left_operand=to_ast_node(v[0]),
+                       right_operand=to_ast_node(v[1]))
     elif k == OrNode.NodeName:
-        node = OrNode(left_operand=v[0],
-                        right_operand=v[1])
+        node = OrNode(left_operand=to_ast_node(v[0]),
+                      right_operand=to_ast_node(v[1]))
     elif k == SemiNode.NodeName:
-        node = SemiNode(left_operand=v[0],
-                        right_operand=v[1])
+        node = SemiNode(left_operand=to_ast_node(v[0]),
+                        right_operand=to_ast_node(v[1]))
     elif k == NotNode.NodeName:
-        node = NotNode(body=v)
+        node = NotNode(body=to_ast_node(v))
     elif k == RedirNode.NodeName:
         node = RedirNode(line_number=v[0],
-                         node=v[1],
-                         redir_list=v[2])
+                         node=to_ast_node(v[1]),
+                         redir_list=to_redirs(v[2]))
     elif k == BackgroundNode.NodeName:
         node = BackgroundNode(line_number=v[0],
-                              node=v[1],
-                              redir_list=v[2])
+                              node=to_ast_node(v[1]),
+                              redir_list=to_redirs(v[2]))
     elif k == DefunNode.NodeName:
         node = DefunNode(line_number=v[0],
                          name=v[1],
-                         body=v[2])
+                         body=to_ast_node(v[2]))
     elif k == ForNode.NodeName:
         node = ForNode(line_number=v[0],
-                       argument=v[1],
-                       body=v[2],
+                       argument=to_args(v[1]),
+                       body=to_ast_node(v[2]),
                        variable=v[3])
     elif k == WhileNode.NodeName:
-        node = WhileNode(test=v[0],
-                         body=v[1])
+        node = WhileNode(test=to_ast_node(v[0]),
+                         body=to_ast_node(v[1]))
     elif k == IfNode.NodeName:
-        node = IfNode(cond=v[0],
-                      then_b=v[1],
-                      else_b=v[2])
+        node = IfNode(cond=to_ast_node(v[0]),
+                      then_b=to_ast_node(v[1]),
+                      else_b=to_ast_node(v[2]))
     elif k == CaseNode.NodeName:
         node = CaseNode(line_number=v[0],
-                        argument=v[1],
-                        cases=v[2])
+                        argument=to_arg(v[1]),
+                        cases=to_case_list(v[2]))
     else:
         raise ValueError()
     return node
+
+def to_ast_nodes(node_list):
+    new_node_list = [to_ast_node(ast_node) for ast_node in node_list]
+    return new_node_list
+
+def to_assigns(assignments):
+    new_assignments = []
+    for name, val in assignments:
+        new_assignments.append(make_kv(name, to_arg(val)))
+    return new_assignments
+
+def to_redirs(redir_list):
+    new_redir_list = [to_redir(redir) for redir in redir_list]
+    return new_redir_list
+
+def to_redir(redir):
+    k, v = redir
+    if k == "File":
+        return make_kv(k, 
+                       [v[0],
+                        v[1],
+                        to_arg(v[2])])
+    elif k == "Dup":
+        return make_kv(k, 
+                       [v[0],
+                        v[1],
+                        to_arg(v[2])])
+    elif k == "Heredoc":
+        return make_kv(k, 
+                       [v[0],
+                        v[1],
+                        to_arg(v[2])])
+    assert(False)
+
+def to_args(arg_list):
+    new_arg_list = [to_arg(arg) for arg in arg_list]
+    return new_arg_list
+
+## TODO: Make this return an Arg (since we have that class already)
+def to_arg(arg_char_list):
+    new_arg_char_list = [to_arg_char(arg_char) for arg_char in arg_char_list]
+    return new_arg_char_list
+
+def to_arg_char(arg_char):
+    k, v = arg_char
+    if k == "C":
+        return arg_char
+    elif k == "E":
+        return arg_char
+    elif k == "T":
+        return arg_char
+    elif k == "A":
+        return make_kv(k, to_arg(v))
+    elif k == "V":
+        return make_kv(k,
+                       [v[0],
+                        v[1],
+                        v[2],
+                        to_arg(v[3])])
+    elif k == "Q":
+        return make_kv(k, to_arg(v))
+    elif k == "B":
+        return make_kv(k, to_ast_node(v))
+    assert(False)
+
+def to_case_list(case_list):
+    new_case_list = [(to_args(case[0]), to_ast_node(case[1])) 
+                     for case in case_list]
+    return new_case_list

--- a/compiler/shell_ast/untyped_to_ast.py
+++ b/compiler/shell_ast/untyped_to_ast.py
@@ -1,0 +1,60 @@
+
+from shell_ast.ast_node import *
+
+## TODO: Recurse in necessary subfields and iterate deep
+def to_ast_node(obj) -> AstNode:
+    k, v = obj
+    if k == PipeNode.NodeName:
+        node = PipeNode(is_background=v[0],
+                        items=v[1])
+    elif k == CommandNode.NodeName:
+        node = CommandNode(line_number=v[0],
+                           assignments=v[1],
+                           arguments=v[2],
+                           redir_list=v[3])
+    elif k == SubshellNode.NodeName:
+        node = SubshellNode(line_number=v[0],
+                            body=v[1],
+                            redir_list=v[2])
+    elif k == AndNode.NodeName:
+        node = AndNode(left_operand=v[0],
+                        right_operand=v[1])
+    elif k == OrNode.NodeName:
+        node = OrNode(left_operand=v[0],
+                        right_operand=v[1])
+    elif k == SemiNode.NodeName:
+        node = SemiNode(left_operand=v[0],
+                        right_operand=v[1])
+    elif k == NotNode.NodeName:
+        node = NotNode(body=v)
+    elif k == RedirNode.NodeName:
+        node = RedirNode(line_number=v[0],
+                         node=v[1],
+                         redir_list=v[2])
+    elif k == BackgroundNode.NodeName:
+        node = BackgroundNode(line_number=v[0],
+                              node=v[1],
+                              redir_list=v[2])
+    elif k == DefunNode.NodeName:
+        node = DefunNode(line_number=v[0],
+                         name=v[1],
+                         body=v[2])
+    elif k == ForNode.NodeName:
+        node = ForNode(line_number=v[0],
+                       argument=v[1],
+                       body=v[2],
+                       variable=v[3])
+    elif k == WhileNode.NodeName:
+        node = WhileNode(test=v[0],
+                         body=v[1])
+    elif k == IfNode.NodeName:
+        node = IfNode(cond=v[0],
+                      then_b=v[1],
+                      else_b=v[2])
+    elif k == CaseNode.NodeName:
+        node = CaseNode(line_number=v[0],
+                        argument=v[1],
+                        cases=v[2])
+    else:
+        raise ValueError()
+    return node

--- a/compiler/shell_ast/untyped_to_ast.py
+++ b/compiler/shell_ast/untyped_to_ast.py
@@ -124,6 +124,7 @@ def to_arg_char(arg_char):
     assert(False)
 
 def to_case_list(case_list):
-    new_case_list = [(to_args(case[0]), to_ast_node(case[1])) 
+    new_case_list = [{'cpattern': to_args(case['cpattern']), 
+                      'cbody': to_ast_node(case['cbody'])} 
                      for case in case_list]
     return new_case_list


### PR DESCRIPTION
The goal of this PR is to implement the first step towards resolving #671.

- [X] Introduce proper classes for all command AST nodes
- [x] Create a function that transforms an untyped AST to a complete typed AST (eventually this will be moved to libdash)
- [x] Make sure that PaSh always deals with the typed AST, and only makes it untyped before passing it to the unparser
- [x] Clean up all obsolete code and comments