### PR TITLE
Pin pash-annotations version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 graphviz
 libdash
-pash-annotations>=0.2.0
+pash-annotations==0.2.0
 shasta==0.1.0
 sh-expand


### PR DESCRIPTION
PaSh Annotations will have some breaking changes introduced soon to its new minor version, so I pin its version to 0.2