### PR TITLE
Remove lists as default arguments in functions

### DIFF
--- a/compiler/definitions/ir/dfg_node.py
+++ b/compiler/definitions/ir/dfg_node.py
@@ -27,12 +27,13 @@ class DFGNode:
     def __init__(
         self,
         cmd_invocation_with_io_vars,
-        com_redirs=[],
-        com_assignments=[],
+        com_redirs=None,
+        com_assignments=None,
         parallelizer_list=None,
         cmd_related_properties=None,
     ):
-        # TODO []: default parameters!
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
 
         ## @KK: can this be deleted? Was there another id in the member attributes before?
         ## Add a unique identifier to each DFGNode since id() is not guaranteed to be unique for objects that have different lifetimes.

--- a/compiler/definitions/ir/nodes/dfs_split_reader.py
+++ b/compiler/definitions/ir/nodes/dfs_split_reader.py
@@ -9,10 +9,14 @@ class DFSSplitReader(DFGNode):
         outputs,
         com_name,
         com_category,
-        com_options=[],
-        com_redirs=[],
-        com_assignments=[],
+        com_options=None,
+        com_redirs=None,
+        com_assignments=None,
     ):
+        com_options = [] if com_options is None else com_options
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
+
         super().__init__(
             inputs,
             outputs,

--- a/compiler/definitions/ir/nodes/dgsh_tee.py
+++ b/compiler/definitions/ir/nodes/dgsh_tee.py
@@ -10,8 +10,9 @@ from definitions.ir.dfg_node import *
 
 
 class DGSHTee(DFGNode):
-    def __init__(self, cmd_invocation_with_io_vars, com_redirs=[], com_assignments=[]):
-        # TODO []: default
+    def __init__(self, cmd_invocation_with_io_vars, com_redirs=None, com_assignments=None):
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
         super().__init__(
             cmd_invocation_with_io_vars,
             com_redirs=com_redirs,

--- a/compiler/definitions/ir/nodes/eager.py
+++ b/compiler/definitions/ir/nodes/eager.py
@@ -12,8 +12,10 @@ from definitions.ir.dfg_node import *
 
 
 class Eager(DFGNode):
-    def __init__(self, cmd_invocation_with_io_vars, com_redirs=[], com_assignments=[]):
-        # TODO []: default
+    def __init__(self, cmd_invocation_with_io_vars, com_redirs=None, com_assignments=None):
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
+
         super().__init__(
             cmd_invocation_with_io_vars,
             com_redirs=com_redirs,

--- a/compiler/definitions/ir/nodes/hdfs_cat.py
+++ b/compiler/definitions/ir/nodes/hdfs_cat.py
@@ -8,10 +8,14 @@ class HDFSCat(DFGNode):
         outputs,
         com_name,
         com_category,
-        com_options=[],
-        com_redirs=[],
-        com_assignments=[],
+        com_options=None,
+        com_redirs=None,
+        com_assignments=None,
     ):
+        com_options = [] if com_options is None else com_options
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
+
         assert str(com_name) == "hdfs"
         assert str(com_options[0][1]) == "dfs" and str(com_options[1][1]) == "-cat"
         super().__init__(

--- a/compiler/definitions/ir/nodes/pash_split.py
+++ b/compiler/definitions/ir/nodes/pash_split.py
@@ -14,12 +14,13 @@ class Split(DFGNode):
     def __init__(
         self,
         cmd_invocation_with_io_vars,
-        com_redirs=[],
-        com_assignments=[],
+        com_redirs=None,
+        com_assignments=None,
         parallelizer_list=None,
         cmd_related_properties=None,
     ):
-        # TODO []: default arguments!
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
         super().__init__(
             cmd_invocation_with_io_vars=cmd_invocation_with_io_vars,
             com_redirs=com_redirs,

--- a/compiler/definitions/ir/nodes/r_merge.py
+++ b/compiler/definitions/ir/nodes/r_merge.py
@@ -10,12 +10,13 @@ class RMerge(DFGNode):
     def __init__(
         self,
         cmd_invocation_with_io_vars,
-        com_redirs=[],
-        com_assignments=[],
+        com_redirs=None,
+        com_assignments=None,
         parallelizer_list=None,
         cmd_related_properties=None,
     ):
-        # TODO []: default arguments!
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
         super().__init__(
             cmd_invocation_with_io_vars=cmd_invocation_with_io_vars,
             com_redirs=com_redirs,

--- a/compiler/definitions/ir/nodes/r_split.py
+++ b/compiler/definitions/ir/nodes/r_split.py
@@ -21,12 +21,13 @@ class RSplit(DFGNode):
     def __init__(
         self,
         cmd_invocation_with_io_vars,
-        com_redirs=[],
-        com_assignments=[],
+        com_redirs=None,
+        com_assignments=None,
         parallelizer_list=None,
         cmd_related_properties=None,
     ):
-        # TODO []: default arguments!
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
         super().__init__(
             cmd_invocation_with_io_vars=cmd_invocation_with_io_vars,
             com_redirs=com_redirs,

--- a/compiler/definitions/ir/nodes/r_unwrap.py
+++ b/compiler/definitions/ir/nodes/r_unwrap.py
@@ -10,12 +10,13 @@ class RUnwrap(DFGNode):
     def __init__(
         self,
         cmd_invocation_with_io_vars,
-        com_redirs=[],
-        com_assignments=[],
+        com_redirs=None,
+        com_assignments=None,
         parallelizer_list=None,
         cmd_related_properties=None,
     ):
-        # TODO []: default
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
         super().__init__(
             cmd_invocation_with_io_vars,
             com_redirs=com_redirs,

--- a/compiler/definitions/ir/nodes/r_wrap.py
+++ b/compiler/definitions/ir/nodes/r_wrap.py
@@ -15,13 +15,14 @@ class RWrap(DFGNode):
     def __init__(
         self,
         cmd_invocation_with_io_vars,
-        com_redirs=[],
-        com_assignments=[],
+        com_redirs=None,
+        com_assignments=None,
         parallelizer_list=None,
         cmd_related_properties=None,
         wrapped_node_name=None,
     ):
-        # TODO []: default
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
         self.wrapped_node_name = wrapped_node_name
         super().__init__(
             cmd_invocation_with_io_vars,

--- a/compiler/definitions/ir/nodes/remote_pipe.py
+++ b/compiler/definitions/ir/nodes/remote_pipe.py
@@ -8,10 +8,14 @@ class RemotePipe(DFGNode):
         outputs,
         com_name,
         com_category,
-        com_options=[],
-        com_redirs=[],
-        com_assignments=[],
+        com_options=None,
+        com_redirs=None,
+        com_assignments=None,
     ):
+        com_options = [] if com_options is None else com_options
+        com_redirs = [] if com_redirs is None else com_redirs
+        com_assignments = [] if com_assignments is None else com_assignments
+
         super().__init__(
             inputs,
             outputs,

--- a/compiler/dspash/worker_manager.py
+++ b/compiler/dspash/worker_manager.py
@@ -89,8 +89,8 @@ class WorkerConnection:
 
 
 class WorkersManager:
-    def __init__(self, workers: WorkerConnection = []):
-        self.workers = workers
+    def __init__(self, workers: WorkerConnection = None):
+        self.workers = [] if workers is None else workers
         self.host = socket.gethostbyname(socket.gethostname())
         self.args = copy.copy(config.pash_args)
         # Required to create a correct multi sink graph

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -233,7 +233,8 @@ def add_file_id_vars(command_invocation_with_io, fileIdGen):
     return command_invocation_with_io_vars, dfg_edges
 
 
-def compile_command_to_DFG(fileIdGen, command, options, redirections=[]):
+def compile_command_to_DFG(fileIdGen, command, options, redirections=None):
+    redirections = [] if redirections is None else redirections
     command_invocation: CommandInvocationInitial = parse_arg_list_to_command_invocation(
         command, options
     )

--- a/compiler/shell_ast/ast_util.py
+++ b/compiler/shell_ast/ast_util.py
@@ -117,7 +117,8 @@ def redir_file_to_stdin(arg):
     return make_kv("File", ["From", 0, arg])
 
 
-def make_background(body, redirections=[]):
+def make_background(body, redirections=None):
+    redirections = [] if redirections is None else redirections
     lineno = 0
     node = make_kv("Background", [lineno, body, redirections])
     return node
@@ -128,13 +129,16 @@ def make_backquote(node):
     return node
 
 
-def make_subshell(body, redirections=[]):
+def make_subshell(body, redirections=None):
+    redirections = [] if redirections is None else redirections
     lineno = 0
     node = make_kv("Subshell", [lineno, body, redirections])
     return node
 
 
-def make_command(arguments, redirections=[], assignments=[]):
+def make_command(arguments, redirections=None, assignments=None):
+    redirections = [] if redirections is None else redirections
+    assignments = [] if assignments is None else assignments
     lineno = 0
     node = make_kv("Command", [lineno, assignments, arguments, redirections])
     return node


### PR DESCRIPTION
Fixes #485 

Replace lists as default arguments with the `var = [] if var is None else var` pattern.