### PR TITLE
feat: --assert_all_regions_parallelizable flag that has the same func…

### DIFF
--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -57,7 +57,12 @@ class BaseParser(argparse.ArgumentParser):
         )
         self.add_argument(
             "--assert_compiler_success",
-            help="assert that the compiler succeeded (used to make tests more robust)",
+            help="assert that the compiler succeeded with no general error occuring",
+            action="store_true",
+        )
+        self.add_argument(
+            "--assert_all_regions_parallelizable",
+            help="assert that the compiler succeeded with all regions being parallelizable and no general error occuring (used to make tests more robust)",
             action="store_true",
         )
         self.add_argument(

--- a/compiler/cli.py
+++ b/compiler/cli.py
@@ -62,7 +62,7 @@ class BaseParser(argparse.ArgumentParser):
         )
         self.add_argument(
             "--assert_all_regions_parallelizable",
-            help="assert that the compiler succeeded with all regions being parallelizable and no general error occuring (used to make tests more robust)",
+            help="assert that the compiler succeeded with all regions being parallelizable and no general error occuring (used to make tests more robust); more strict than --assert_compiler_success flag",
             action="store_true",
         )
         self.add_argument(

--- a/compiler/custom_error.py
+++ b/compiler/custom_error.py
@@ -3,3 +3,10 @@ class UnparallelizableError(Exception):
 
 class AdjLineNotImplementedError(Exception):
     pass
+
+# to be raised in pash_compiler if a UnparallelizableError is caught at any point running the compiler
+#   primarily to differentiate 
+#       --assert_compiler_success (exit with error only under general exceptions caught) 
+#       --assert_all_regions_parallelizable (exit with error when regions are found not parallelizable + general exceptions)
+class NotAllRegionParallelizableError(Exception): 
+    pass 

--- a/compiler/orchestrator_runtime/pash_init_setup.sh
+++ b/compiler/orchestrator_runtime/pash_init_setup.sh
@@ -13,6 +13,7 @@ export pash_output_time_flag=1
 export pash_execute_flag=1
 export pash_dry_run_compiler_flag=0
 export pash_assert_compiler_success_flag=0
+export pash_assert_all_regions_parallelizable_flag=0
 export pash_checking_log_file=0
 export pash_checking_debug_level=0
 export pash_avoid_pash_runtime_completion_flag=0
@@ -49,6 +50,10 @@ do
 
     if [ "--assert_compiler_success" == "$item" ]; then
         export pash_assert_compiler_success_flag=1
+    fi
+
+    if [ "--assert_all_regions_parallelizable" == "$item" ]; then
+        export pash_assert_all_regions_parallelizable_flag=1
     fi
 
     if [ "--log_file" == "$item" ]; then

--- a/compiler/pash_compilation_server.py
+++ b/compiler/pash_compilation_server.py
@@ -253,7 +253,7 @@ class Scheduler:
         process_id = self.get_next_id()
         run_parallel = False
         compile_success = False
-        all_region_parallelizable = True 
+        current_region_parallelizable = True 
 
         variable_reading_start_time = datetime.now()
         # Read any shell variables files if present
@@ -278,7 +278,7 @@ class Scheduler:
             )
         except NotAllRegionParallelizableError: 
             ast_or_ir = None 
-            all_region_parallelizable = False
+            current_region_parallelizable = False
                     
 
         daemon_compile_end_time = datetime.now()
@@ -334,9 +334,9 @@ class Scheduler:
             response = server_util.success_response(
                 f"{process_id} {compiled_script_file} {var_file} {input_ir_file}"
             )
-        elif not all_region_parallelizable: 
-            # send specified message to say not all regions are parallelizable instead of general exception caught
-            response = server_util.error_response(f"{process_id} not all regions are parallelizable; failed to compile")
+        elif not current_region_parallelizable: 
+            # send specified message to say current region is not parallelizable instead of general exception caught
+            response = server_util.error_response(f"{process_id} current region is not parallelizable; failed to compile")
             self.unsafe_running = True
         else:
             response = server_util.error_response(f"{process_id} failed to compile")
@@ -349,7 +349,7 @@ class Scheduler:
         ##  nothing will run in this case also 
         if (not compile_success and config.pash_args.assert_all_regions_parallelizable): 
             pass 
-        elif (not compile_success and all_region_parallelizable and config.pash_args.assert_compiler_success): 
+        elif (not compile_success and current_region_parallelizable and config.pash_args.assert_compiler_success): 
             pass 
         else:
             self.running_procs += 1

--- a/compiler/pash_compiler.py
+++ b/compiler/pash_compiler.py
@@ -96,8 +96,10 @@ def compile_ir(ir_filename, compiled_script_file, args, compiler_config):
         )
     except ExpansionError as e: 
         log("WARNING: Exception caught because some region(s) are not expandable and therefore unparallelizable:", e) 
+        raise NotAllRegionParallelizableError()
     except UnparallelizableError as e: 
         log("WARNING: Exception caught because some region(s) are unparallelizable:", e) 
+        raise NotAllRegionParallelizableError()
         # log(traceback.format_exc()) # uncomment for exact trace report (PaSh user should see informative messages for unparellizable regions) 
     except (AdjLineNotImplementedError, NotImplementedError) as e: 
         log("WARNING: Exception caught because some part is not implemented:", e)

--- a/evaluation/tests/test_evaluation_scripts.sh
+++ b/evaluation/tests/test_evaluation_scripts.sh
@@ -189,7 +189,7 @@ execute_tests() {
 }
 
 execute_tests "" "${script_microbenchmarks[@]}"
-execute_tests "--assert_compiler_success" "${pipeline_microbenchmarks[@]}"
+execute_tests "--assert_all_regions_parallelizable" "${pipeline_microbenchmarks[@]}"
 
 #cat ${results_time} | sed 's/,/./' > /tmp/a
 #cat /tmp/a | sed 's/@/,/' > ${results_time}


### PR DESCRIPTION
To introduce the `--assert_all_regions_parallelizable` flag (should exit with error when both `UnparallelizableError` and general exception are caught) and changing the original `--assert_compiler_success` flag to exiting with error only when general exceptions are caught (does not exit with error when `UnparallelizableError` are caught), the following were added: 

- `compiler/orchestrator_runtime/pash_init_setup.sh`, `compiler/cli.py` : set-up and add information regarding `--assert_all_regions_parallelizable` flag for pash to recognize 
- `compiler/custom_error.py`: introduce `NotAllRegionParallelizableError` to be raised when `UnparallelizableError` are caught in the `compile.ir` function in `pash/compiler/pash_compiler.py` ; 
    - the `NotAllRegionParallelizableError` will be caught in `compiler/pash_compilation_server.py` when the `compile.ir` function is called; if this error is caught, the new variable `all_region_parallelizable` in `compiler/pash_compilation_server.py` will be marked false 
    - to differentiate all regions not parallelizable from general error, a `error_response` with a different error message is saved in the compiler server 
    - don't increase the running procs if `assert_compiler_success` flag is on and `compile_success` is false but `all_region_parallelizable` is true (some general exceptions caught) ; or `assert_all_regions_parallelizable` flag on and `compile_success` is false because of both general exceptions or unparallelizable region 
  
- `compiler/orchestrator_runtime/pash_prepare_call_compiler.sh`: marks variable `pash_all_region_parallelizable` if `error_response` contains message regarding regions not being parallelizable. We should exit on error when, 
   - `assert_all_regions_parallelizable` flag on and `runtime_return_code != 0` : general exception 
   - `assert_all_regions_parallelizable` flag on and `pash_all_region_parallelizable != 0` : some region is not parallelizable 
   - `assert_compiler_success_flag` flag on and `runtime_return_code != 0` and `pash_all_region_parallelizable == 0` : general exception (and not error because some regions were not parallelizable) 

- `evaluation/tests/test_evaluation_scripts.sh` : when executing tests, change `--assert_compiler_success` to `--assert_all_regions_parallelizable`, since what assert_compiler_success originally does is now carried out by `--assert_all_regions_parallelizable`

Tested the above for expected behavior by running some intro scripts in the directory, and it does seem like we are exiting with error for `--assert_compiler_success` only when general exceptions are caught and not the unparallelizable ones. We are also exiting on error for both reasons when `--assert_all_regions_parallelizable` flag is on. When both flags are used at the same time, we follow the behavior of `--assert_all_regions_parallelizable`. PaSh testing scripts locally also seems to pass all tests. 
