### PR TITLE
Add escape sequence parsing when reading variables

### DIFF
--- a/compiler/env_vars_util.py
+++ b/compiler/env_vars_util.py
@@ -75,6 +75,10 @@ def read_vars_file(var_file_path):
             if var_value is not None and len(var_value) >= 2 and \
                var_value[0] == "\"" and var_value[-1] == "\"":
                 var_value = var_value[1:-1]                
+
+            ## Parse escapes
+            if var_value is not None:
+                var_value = bytes(var_value, "utf-8").decode("unicode_escape")
                 
             vars_dict[var_name] = (var_type, var_value)
 


### PR DESCRIPTION
Potential resolution to #726. On a Ubuntu 24.04 VM with Bash 5.2.21, this passes 52/54 of the compiler tests (all except `tr-test.sh`), vs only 18/54 without.