### PR TITLE
Add passing bash version to read_vars_file

### DIFF
--- a/compiler/config.py
+++ b/compiler/config.py
@@ -98,6 +98,9 @@ def load_config(config_file_path=""):
     with open(config_file_path) as config_file:
         pash_config = json.load(config_file)
 
+    # set configuration variables gotten dynamically
+    pash_config["bash_version"] = get_bash_version()
+
     if not pash_config:
         raise Exception(
             "No valid configuration could be loaded from {}".format(config_file_path)
@@ -174,3 +177,7 @@ def set_vars_file(var_file_path: str, var_dict: dict):
     global config
     config["shell_variables"] = var_dict
     config["shell_variables_file_path"] = var_file_path
+
+def get_bash_version():
+    out = subprocess.run(["bash", "-c", "echo ${BASH_VERSINFO[@]}"], capture_output=True)
+    return tuple(int(v) for v in out.stdout.split(b" ")[:4])

--- a/compiler/config.py
+++ b/compiler/config.py
@@ -38,6 +38,8 @@ PASH_TMP_PREFIX = os.getenv("PASH_TMP_PREFIX")
 
 SOCKET_BUF_SIZE = 8192
 
+BASH_VERSION = tuple(int(i) for i in os.getenv("PASH_BASH_VERSION").split(" "))
+
 
 ##
 ## Global configuration used by all pash components
@@ -97,9 +99,6 @@ def load_config(config_file_path=""):
         config_file_path = "{}/compiler/config.json".format(PASH_TOP)
     with open(config_file_path) as config_file:
         pash_config = json.load(config_file)
-
-    # set configuration variables gotten dynamically
-    pash_config["bash_version"] = get_bash_version()
 
     if not pash_config:
         raise Exception(
@@ -177,7 +176,3 @@ def set_vars_file(var_file_path: str, var_dict: dict):
     global config
     config["shell_variables"] = var_dict
     config["shell_variables_file_path"] = var_file_path
-
-def get_bash_version():
-    out = subprocess.run(["bash", "-c", "echo ${BASH_VERSINFO[@]}"], capture_output=True)
-    return tuple(int(v) for v in out.stdout.split(b" ")[:4])

--- a/compiler/pash_compilation_server.py
+++ b/compiler/pash_compilation_server.py
@@ -257,7 +257,7 @@ class Scheduler:
 
         variable_reading_start_time = datetime.now()
         # Read any shell variables files if present
-        vars_dict = env_vars_util.read_vars_file(var_file)
+        vars_dict = env_vars_util.read_vars_file(var_file, config.config["bash_version"])
         config.set_vars_file(var_file, vars_dict)
 
         variable_reading_end_time = datetime.now()

--- a/compiler/pash_compilation_server.py
+++ b/compiler/pash_compilation_server.py
@@ -257,7 +257,7 @@ class Scheduler:
 
         variable_reading_start_time = datetime.now()
         # Read any shell variables files if present
-        vars_dict = env_vars_util.read_vars_file(var_file, config.config["bash_version"])
+        vars_dict = env_vars_util.read_vars_file(var_file, config.BASH_VERSION)
         config.set_vars_file(var_file, vars_dict)
 
         variable_reading_end_time = datetime.now()

--- a/compiler/pash_compiler.py
+++ b/compiler/pash_compiler.py
@@ -57,7 +57,7 @@ def main_body():
     runtime_config = config.config["distr_planner"]
 
     ## Read any shell variables files if present
-    vars_dict = env_vars_util.read_vars_file(args.var_file, config.config["bash_version"])
+    vars_dict = env_vars_util.read_vars_file(args.var_file, config.BASH_VERSION)
     config.set_vars_file(args.var_file, vars_dict)
 
     log("Input:", args.input_ir, "Compiled file:", args.compiled_script_file)

--- a/compiler/pash_compiler.py
+++ b/compiler/pash_compiler.py
@@ -57,7 +57,7 @@ def main_body():
     runtime_config = config.config["distr_planner"]
 
     ## Read any shell variables files if present
-    vars_dict = env_vars_util.read_vars_file(args.var_file)
+    vars_dict = env_vars_util.read_vars_file(args.var_file, config.config["bash_version"])
     config.set_vars_file(args.var_file, vars_dict)
 
     log("Input:", args.input_ir, "Compiled file:", args.compiled_script_file)

--- a/pa.sh
+++ b/pa.sh
@@ -31,6 +31,9 @@ then
     exit
 fi
 
+## get bash version for pash
+export PASH_BASH_VERSION="${BASH_VERSINFO[@]:0:3}"
+
 ## Create a temporary directory where PaSh can use for temporary files and logs
 export PASH_TMP_PREFIX="$(mktemp -d /tmp/pash_XXXXXXX)/"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ graphviz
 libdash
 pash-annotations==0.2.2
 shasta==0.1.0
-sh-expand>=0.1.3
+sh-expand>=0.1.6


### PR DESCRIPTION
Use the bash version to determine how to parse the vars file as discussed in binpash/sh-expand#7. Should be merged at the same time as those changes (and will fail any tests until then).