### PR TITLE
Set IFS to default before use in compiler.

### DIFF
--- a/compiler/orchestrator_runtime/pash_prepare_call_compiler.sh
+++ b/compiler/orchestrator_runtime/pash_prepare_call_compiler.sh
@@ -49,12 +49,17 @@ else
     pash_runtime_return_code=1
 fi
 
+# save IFS to restore after field splitting
+[ -n "${IFS+x}" ] && saved_IFS=$IFS
+unset IFS
 # Get assigned process id
 # We need to split the daemon response into elements of an array by
 # shell's field splitting.
 # shellcheck disable=SC2206
 response_args=($daemon_response)
 process_id=${response_args[1]}
+
+[ -n "${saved_IFS+x}" ] && IFS="$saved_IFS"
 
 pash_redir_output echo "$$: (2) Compiler exited with code: $pash_runtime_return_code"
 

--- a/evaluation/tests/interface_tests/run.sh
+++ b/evaluation/tests/interface_tests/run.sh
@@ -321,6 +321,12 @@ test_redir_dup()
     $shell redir-dup.sh
 }
 
+test_IFS()
+{
+    local shell=$1
+    $shell test-IFS.sh
+}
+
 ## We run all tests composed with && to exit on the first that fails
 if [ "$#" -eq 0 ]; then
     run_test test1
@@ -365,6 +371,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_star
     run_test test_env_vars
     run_test test_redir_dup
+    run_test test_IFS
 else
     for testname in $@
     do

--- a/evaluation/tests/interface_tests/test-IFS.sh
+++ b/evaluation/tests/interface_tests/test-IFS.sh
@@ -1,0 +1,5 @@
+IFS=/
+curr_dir=/home/bolun/programming/pash
+for name in $curr_dir; do
+  echo "$name"
+done

--- a/evaluation/tests/interface_tests/test-IFS.sh
+++ b/evaluation/tests/interface_tests/test-IFS.sh
@@ -1,5 +1,5 @@
 IFS=/
-curr_dir=/home/bolun/programming/pash
+curr_dir=/test1/test2/test3/test4
 for name in $curr_dir; do
   echo "$name"
 done

--- a/runtime/wait_for_output_and_sigpipe_rest.sh
+++ b/runtime/wait_for_output_and_sigpipe_rest.sh
@@ -15,7 +15,7 @@ export internal_exec_status=$?
 # This value may contains multiple pids as a whitespace-separated string, and
 # we must split it as multiple pids by shell's field splitting.
 # shellcheck disable=SC2086
-(> /dev/null 2>&1 kill -SIGPIPE $pids_to_kill || true)
+(unset IFS; > /dev/null 2>&1 kill -SIGPIPE $pids_to_kill || true)
 
 ##
 ## Old way of waiting, very inefficient.


### PR DESCRIPTION
Resolves #718. In a few places, the default value of IFS is assumed, leading to pa.sh crashing when it’s reset. This saves the old IFS and restores it after the word splitting.