### PR TITLE
Fix double exit bug in parallel pipelines

### DIFF
--- a/compiler/pash_compilation_server.py
+++ b/compiler/pash_compilation_server.py
@@ -379,6 +379,7 @@ class Scheduler:
                 ]
             )
 
+        assert self.running_procs > 0
         self.running_procs -= 1
         if self.running_procs == 0:
             self.unsafe_running = False

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -144,7 +144,6 @@ else
             trap inform_daemon_exit SIGTERM SIGINT EXIT
             export SCRIPT_TO_EXECUTE="$pash_script_to_execute"
             source "$RUNTIME_DIR/pash_restore_state_and_execute.sh"
-            inform_daemon_exit
         }
         # Should we redirect errors aswell?
         # TODO: capturing the return state here isn't completely correct. 

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -141,6 +141,8 @@ else
         pash_redir_output echo "$$: (5) BaSh script exited with ec: $pash_runtime_final_status"
     else 
         function run_parallel() {
+            # ideally we'd call inform_daemon_exit with the EXIT handler,
+            # but it isn't called on Ubuntu 20.04 (for no clear reason)
             trap inform_daemon_exit SIGTERM SIGINT
             export SCRIPT_TO_EXECUTE="$pash_script_to_execute"
             source "$RUNTIME_DIR/pash_restore_state_and_execute.sh"

--- a/compiler/pash_runtime.sh
+++ b/compiler/pash_runtime.sh
@@ -141,9 +141,10 @@ else
         pash_redir_output echo "$$: (5) BaSh script exited with ec: $pash_runtime_final_status"
     else 
         function run_parallel() {
-            trap inform_daemon_exit SIGTERM SIGINT EXIT
+            trap inform_daemon_exit SIGTERM SIGINT
             export SCRIPT_TO_EXECUTE="$pash_script_to_execute"
             source "$RUNTIME_DIR/pash_restore_state_and_execute.sh"
+            inform_daemon_exit
         }
         # Should we redirect errors aswell?
         # TODO: capturing the return state here isn't completely correct. 


### PR DESCRIPTION
Fixes #736, #738. This wasn’t a problem on Ubuntu 20.04 because the EXIT handler wasn’t called (for no obvious reason), so it only exited once.