### PR TITLE
Fix —assert-* checks

### DIFF
--- a/compiler/orchestrator_runtime/pash_prepare_call_compiler.sh
+++ b/compiler/orchestrator_runtime/pash_prepare_call_compiler.sh
@@ -40,7 +40,8 @@ pash_redir_output echo "$$: (2) Before asking the daemon for compilation..."
 msg="Compile:${pash_compiled_script_file}| Variable File:${pash_runtime_shell_variables_file}| Input IR File:${pash_input_ir_file}"
 daemon_response=$(pash_communicate_daemon "$msg") # Blocking step, daemon will not send response until it's safe to continue
 
-if [[ "$daemon_response" == *"not all regions are parallelizable"* ]]; then
+# WARNING: finicky!
+if [[ "$daemon_response" == *"not"*"parallelizable"* ]]; then
     pash_all_region_parallelizable=1 
 else 
     pash_all_region_parallelizable=0 

--- a/compiler/orchestrator_runtime/pash_prepare_call_compiler.sh
+++ b/compiler/orchestrator_runtime/pash_prepare_call_compiler.sh
@@ -2,6 +2,13 @@
 
 ## OUTPUT: When it completes it sets "$pash_script_to_execute"
 
+## Let daemon know that this region is done
+function inform_daemon_exit () {
+    ## Send to daemon
+    msg="Exit:${process_id}"
+    daemon_response=$(pash_communicate_daemon_just_send "$msg")
+}
+
 ## Only needed for expansion
 export pash_input_args=( "$@" )
 
@@ -66,17 +73,20 @@ pash_redir_output echo "$$: (2) Compiler exited with code: $pash_runtime_return_
 ## only when --assert_all_regions_parallellizable is used do we care about all regions being parallelizable
 if [ "$pash_all_region_parallelizable" -ne 0 ] && [ "$pash_assert_all_regions_parallelizable_flag" -eq 1 ]; then
     pash_redir_output echo "$$: ERROR: (2) Compiler failed with error code because some regions were not parallelizable: $pash_all_region_parallelizable while assert_all_regions_parallelizable_flag was enabled! Exiting PaSh..."
+    inform_daemon_exit
     exit 1
 fi
 
 if [ "$pash_runtime_return_code" -ne 0 ] && [ "$pash_assert_all_regions_parallelizable_flag" -eq 1 ]; then
     pash_redir_output echo "$$: ERROR: (2) Compiler failed with error code: $pash_runtime_return_code while assert_all_regions_parallelizable_flag was enabled! Exiting PaSh..."
+    inform_daemon_exit
     exit 1
 fi
 
-## for pash_assert_compiler_success_flag, exit when return code is 0 (general exception caught) and not when all regions are parallelizable
+## for pash_assert_compiler_success_flag, exit when return code is not 0 (general exception caught) and when all regions are parallelizable
 if [ "$pash_runtime_return_code" -ne 0 ] && [ "$pash_all_region_parallelizable" -eq 0 ] && [ "$pash_assert_compiler_success_flag" -eq 1 ]; then
     pash_redir_output echo "$$: ERROR: (2) Compiler failed with error code: $pash_runtime_return_code while assert_compiler_success was enabled! Exiting PaSh..."
+    inform_daemon_exit
     exit 1
 fi
 
@@ -93,11 +103,3 @@ if [ "$pash_runtime_return_code" -ne 0 ] || [ "$pash_dry_run_compiler_flag" -eq 
 else
     export pash_script_to_execute="${pash_compiled_script_file}"
 fi
-
-## Let daemon know that this region is done
-function inform_daemon_exit () {
-    ## Send to daemon
-    msg="Exit:${process_id}"
-    daemon_response=$(pash_communicate_daemon_just_send "$msg")
-} 
-


### PR DESCRIPTION
1. Call inform_daemon_exit on —assert_* exit. Otherwise, --assert_compiler_success hangs while pash waits for an exit message that never comes. The tests don’t currently use this flag, but it will be used for #739.

2. Corectly parse is_parallelizable output. Doesn’t affect the tests, since --assert_all_regions_parallelizable failed anyways on the non-zero error code.
