### PR TITLE
Upgrade CI to latest OS versions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,19 +19,19 @@ jobs:
       - name: Build & Push Debian Image
         run: |
             cd scripts/docker/debian
-            docker build -t binpash/pash:debian-10 .
-            docker push binpash/pash:debian-10
+            docker build -t binpash/pash:debian-12 .
+            docker push binpash/pash:debian-12
 
       - name: Build & Push Ubuntu Image
         run: |
             cd scripts/docker/ubuntu
-            docker build -t binpash/pash:ubuntu-18.04 . 
-            docker push binpash/pash:ubuntu-18.04
-            docker tag binpash/pash:ubuntu-18.04 binpash/pash:latest
+            docker build -t binpash/pash:ubuntu-24.04 . 
+            docker push binpash/pash:ubuntu-24.04
+            docker tag binpash/pash:ubuntu-24.04 binpash/pash:latest
             docker push binpash/pash:latest
 
       - name: Build & Push Fedora Image
         run: |
             cd scripts/docker/fedora
-            docker build -t binpash/pash:fedora-35 .
-            docker push binpash/pash:fedora-35
+            docker build -t binpash/pash:fedora-41 .
+            docker push binpash/pash:fedora-41

--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -5,9 +5,9 @@ on:
     types: [published]
 
 env:
-  DEBIAN: pash/debian-10
-  UBUNTU: pash/ubuntu-18.04
-  FEDORA: pash/fedora-35
+  DEBIAN: pash/debian-12
+  UBUNTU: pash/ubuntu-24.04
+  FEDORA: pash/fedora-41
   IMAGENAME: pash/pash
 
 jobs:

--- a/docs/contributing/contrib.md
+++ b/docs/contributing/contrib.md
@@ -47,7 +47,7 @@ This is a small list of useful docker commands. Docker distinguishes between an 
 ```
 docker images                    # shows all images in the system
 docker ps -a | grep pash         # shows all containers with name pash
-docker run --name NN pash/18.04  # creates a writable container (add `-it` for interactive)
+docker run --name NN pash/24.04  # creates a writable container (add `-it` for interactive)
 docker start -i NN               # starts container (add `-i` to drop straight into shell)
 docker attach NN                 # non-interactive -> interactive
 <CTL+p>, then <CTL+q>            # interactive -> non-interactive
@@ -109,8 +109,8 @@ wsl --set-default-version 2
 
 Install one of the Linux distributions on which PaSh has been tested from the Microsoft Store:
 
-* [Ubuntu 18.04 LTS](https://www.microsoft.com/store/apps/9N9TNGVNDL3Q)
 * [Ubuntu 20.04 LTS](https://www.microsoft.com/store/apps/9n6svws3rx71)
+* [Ubuntu 24.04 LTS](https://www.microsoft.com/store/apps/9nz3klhxdjp5)
 * [Debian GNU/Linux](https://www.microsoft.com/store/apps/9MSVKQC78PK6)
 * [Fedora Remix for WSL](https://www.microsoft.com/store/apps/9n6gdm4k2hnc)
 

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -3,9 +3,9 @@
 
 Docker files for [PaSh](https://github.com/binpash/pash) published on Dockerhub:
 
-* Ubuntu 18.04: [binpash/pash:ubuntu-18.04](https://hub.docker.com/r/binpash/pash)
-* Fedora 35: [binpash/pash:fedora-35](https://hub.docker.com/r/binpash/pash)
-* Debian 10: [binpash/pash:debian-10](https://hub.docker.com/r/binpash/pash)
+* Ubuntu 24.04: [binpash/pash:ubuntu-24.04](https://hub.docker.com/r/binpash/pash)
+* Fedora 41: [binpash/pash:fedora-41](https://hub.docker.com/r/binpash/pash)
+* Debian 12: [binpash/pash:debian-12](https://hub.docker.com/r/binpash/pash)
 
 ## Run locally
 
@@ -28,9 +28,9 @@ docker build -t "pash:latest" .
 
 ## As a Dockerfile
 
-* Ubuntu 18.04: [rendered](https://github.com/binpash/pash/blob/main/scripts/docker/ubuntu/Dockerfile); [raw](https://raw.githubusercontent.com/binpash/pash/main/scripts/docker/ubuntu/Dockerfile)
-* Fedora 35: [rendered](https://github.com/binpash/pash/blob/main/scripts/docker/ubuntu/Dockerfile); [raw](https://raw.githubusercontent.com/binpash/pash/main/scripts/docker/ubuntu/Dockerfile)
-* Debian 10: [rendered](https://github.com/binpash/pash/blob/main/scripts/docker/ubuntu/Dockerfile); [raw](https://raw.githubusercontent.com/binpash/pash/main/scripts/docker/ubuntu/Dockerfile)
+* Ubuntu 24.04: [rendered](https://github.com/binpash/pash/blob/main/scripts/docker/ubuntu/Dockerfile); [raw](https://raw.githubusercontent.com/binpash/pash/main/scripts/docker/ubuntu/Dockerfile)
+* Fedora 41: [rendered](https://github.com/binpash/pash/blob/main/scripts/docker/ubuntu/Dockerfile); [raw](https://raw.githubusercontent.com/binpash/pash/main/scripts/docker/ubuntu/Dockerfile)
+* Debian 12: [rendered](https://github.com/binpash/pash/blob/main/scripts/docker/ubuntu/Dockerfile); [raw](https://raw.githubusercontent.com/binpash/pash/main/scripts/docker/ubuntu/Dockerfile)
 
 To build any of these containers and run it locally:
 

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:12
 SHELL ["/bin/bash", "-c"]
 ## Necessary to avoid interactive responses in installations
 ENV DEBIAN_FRONTEND=noninteractive

--- a/scripts/docker/fedora/Dockerfile
+++ b/scripts/docker/fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:41
 RUN dnf install git -y
 ENV PASH_TOP=/opt/pash
 # download PaSh

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 ## Necessary to avoid interactive responses in installations
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y git


### PR DESCRIPTION
Separate from #745 in case we want to wait and see if it causes any problems.

Separately, the docker containers are a bit out of date (last pushed May 2023), so could whoever has permissions to update those push the new version? (although I’m not sure how important those are to keep up to date).