### PR TITLE
Fix annotation lookup for quoted command names

### DIFF
--- a/ISSUE_741_SOLUTION_README.md
+++ b/ISSUE_741_SOLUTION_README.md
@@ -1,0 +1,196 @@
+# PaSh Issue #741: Quoted Commands Are Not Recognized as Parallelizable
+
+## Status
+
+This document describes the solution and regression coverage for
+[binpash/pash#741](https://github.com/binpash/pash/issues/741).
+
+## Issue summary
+
+PaSh recognizes commands through its annotation library before constructing and
+optimizing a dataflow graph. A command written without quotes was recognized:
+
+```bash
+cat README.md | tr "A-Z" "a-z"
+```
+
+The shell-equivalent form with quoted executable names was not recognized:
+
+```bash
+"cat" README.md | "tr" "A-Z" "a-z"
+```
+
+Before this fix, running the quoted form with
+`--assert_all_regions_parallelizable` failed because PaSh reported that zero of
+one regions were parallelized. The unquoted form succeeded.
+
+## Root cause
+
+Shell quotes control word expansion; they are not part of the resulting
+executable name. Shasta's AST preserves quoted portions as `QArgChar` nodes.
+
+During annotation lookup, PaSh formatted the entire command-name AST with the
+general-purpose `format_arg_chars` function. `QArgChar.format()` intentionally
+reintroduces double quotes for shell rendering, so the annotation lookup received
+`"cat"` rather than `cat`. Since annotations exist for `cat`, not for a command
+literally named `"cat"`, the command was treated as unannotated and therefore
+side-effectful.
+
+## Solution
+
+The fix introduces `remove_quotes_expanded_arg_chars`, a command-name-specific
+formatter that:
+
+1. Accepts normal (`CArgChar`) and escaped (`EArgChar`) characters.
+2. Recursively traverses quoted (`QArgChar`) nodes without emitting their
+   syntactic quote wrappers.
+3. Rejects any other node type with `ValueError`, because command names must be
+   fully expanded before annotation lookup.
+4. Is used only to obtain the executable name for annotation lookup. Arguments,
+   operands, flags, and emitted shell code continue using the existing formatter.
+
+Restricting normalization to the executable name is important: removing quotes
+from operands could change shell semantics through field splitting, globbing, or
+empty-argument handling.
+
+## Changed files
+
+- `src/pash/compiler/util.py`
+  - Adds the recursive `remove_quotes_expanded_arg_chars` helper.
+- `src/pash/compiler/annotations_utils/util_parsing.py`
+  - Uses the helper when looking up annotations for a command name.
+- `evaluation/tests/quoted_cmd.sh`
+  - Adds fully quoted, single-quoted, and mixed-quote command-name regressions.
+- `evaluation/tests/test_evaluation_scripts.sh`
+  - Registers `quoted_cmd` as a pipeline microbenchmark that must be
+    parallelizable.
+
+## Behavioral coverage
+
+The local validation covers:
+
+- Unquoted command names: `cat`
+- Fully double-quoted command names: `"cat"`
+- Fully single-quoted command names: `'cat'`
+- Adjacent mixed segments: `c"a"t`
+- Escaped characters: `c\at`
+- Command names produced by variable expansion: `cmd=cat; "$cmd" ...`
+- Quoted operands, ensuring command-name normalization does not alter arguments
+- Nested quoted AST nodes
+- Empty quoted AST nodes
+- Rejection of unexpanded variable AST nodes
+- Rejection of unknown quoted executables
+- Rejection of executable names containing literal quote characters
+
+## Reproduction
+
+From the repository root with the local Python environment active:
+
+```bash
+export PASH_TOP="$PWD/src/pash"
+export PATH="/opt/homebrew/bin:$PWD/.venv/bin:$PATH"
+
+# Expected to succeed both before and after the fix.
+pash --dry_run_compiler --assert_all_regions_parallelizable -d 1 \
+  -c 'cat README.md | tr "A-Z" "a-z"'
+
+# Failed before the fix and succeeds after it.
+pash --dry_run_compiler --assert_all_regions_parallelizable -d 1 \
+  -c '"cat" README.md | "tr" "A-Z" "a-z"'
+```
+
+## Regression test
+
+The focused regression can be executed without parallel runtime optimization:
+
+```bash
+export PASH_TOP="$PWD/src/pash"
+export PATH="/opt/homebrew/bin:$PWD/.venv/bin:$PATH"
+
+/opt/homebrew/bin/bash evaluation/tests/quoted_cmd.sh > /tmp/quoted-sequential.out
+pash --no_optimize --assert_all_regions_parallelizable -d 1 \
+  evaluation/tests/quoted_cmd.sh > /tmp/quoted-pash.out
+cmp /tmp/quoted-sequential.out /tmp/quoted-pash.out
+```
+
+A successful run exits with status zero and produces byte-for-byte identical
+output.
+
+## Test platforms
+
+The checkout is hosted on Apple Silicon macOS. PaSh's optimized runtime cannot
+currently be built directly there because the upstream `dgsh-macho.s` fails to
+assemble with the installed Apple toolchain. Host-side validation therefore uses
+`--dry_run_compiler` for optimized compilation and `--no_optimize` for semantic
+output comparison.
+
+Optimized end-to-end validation was additionally performed in a clean, native
+ARM64 Ubuntu 24.04 container using Docker with Colima. All runtime helpers,
+including `dgsh-tee`, were rebuilt inside Linux and verified as ARM64 ELF
+executables before tests were run. The repository was mounted read-only while
+the test tree was copied into the container, so the container could not modify
+the working checkout.
+
+## Local validation results
+
+The complete issue-specific validation matrix was executed twice from a clean
+test-output directory. Both runs completed with `VALIDATION_FAILURES=0` and exit
+status zero. Each run included:
+
+- Seven successful positive end-to-end compiler cases
+- Three correctly rejected negative compiler cases
+- Byte-for-byte Bash-versus-PaSh output comparison
+- Seven direct AST normalization cases
+- Rejection of an unexpanded variable AST node
+- Quoted-versus-unquoted annotation-parser equivalence
+- Bash syntax validation
+- Python byte-compilation
+- Black formatting validation for both modified Python modules
+- `git diff --check`
+
+The new `quoted_cmd.sh` regression was then run in Linux in every configuration
+used by the compiler test harness. All four runs exited successfully, satisfied
+`--assert_all_regions_parallelizable`, and produced output byte-for-byte
+identical to Bash:
+
+- `--width 2 --bash`
+- `--width 8 --bash`
+- `--width 2` (Dash backend)
+- `--width 8` (Dash backend)
+
+The complete Linux issue-specific matrix (positive cases, expected rejections,
+all four semantic configurations, AST checks, and annotation-parser checks) was
+run twice with `LINUX_VALIDATION_FAILURES=0`. It was run once more after the
+final mechanical Black formatting change, again with zero failures.
+
+The repository-wide `scripts/run_tests.sh` was also invoked in the clean Linux
+environment. Its optimized intro suite passed 3/3. The existing interface suite
+reported 23/43 passing, with failures across shell arguments, redirections,
+`set -e`, traps, globbing, and IFS behavior rather than the quoted-command path.
+The compiler suite then stalled in the existing `comm-par-test` and
+`comm-par-test2` cases (`comm -23` remained blocked). Terminating their orphaned
+processes also terminated the aggregate harness, so no complete repository-wide
+pass is claimed. The issue-specific test was run independently afterward with
+per-run timeouts and passed all four configurations as described above.
+
+A second repository-wide run used `--no_optimize` to bypass the missing parallel
+runtime. Its completed intro cases passed, but the existing `hello-world-bash`
+case did not terminate on this macOS host, so that run was also stopped rather
+than reported as a complete suite pass.
+
+Finally, source-distribution generation completed, but wheel generation reached
+the project's runtime build step and failed because `eager_lib.c` references the
+Linux-oriented `std_copy` and `send_file` helpers that are unavailable with the
+Apple toolchain. No packaging error involved the files changed for issue #741.
+
+## Review checklist before any commit
+
+- [ ] Review the implementation and regression test.
+- [ ] Confirm all local validation results.
+- [ ] Investigate or confirm the unrelated Linux interface failures and hanging
+      `comm` tests in PaSh's CI environment if a repository-wide green run is
+      required.
+- [ ] Decide whether this documentation file should be included in the eventual
+      commit or retained only as local review notes.
+- [ ] Commit only after explicit approval.
+- [ ] Push or open a pull request only after separate explicit approval.

--- a/evaluation/tests/quoted_cmd.sh
+++ b/evaluation/tests/quoted_cmd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+FILE="$PASH_TOP/../../README.md"
+
+"cat" "$FILE" | "tr" "A-Z" "a-z"
+'cat' "$FILE" | c"a"t | 'tr' 'a-z' 'A-Z'

--- a/evaluation/tests/test_evaluation_scripts.sh
+++ b/evaluation/tests/test_evaluation_scripts.sh
@@ -112,6 +112,7 @@ pipeline_microbenchmarks=(
     tr-test              # Tests all possible behaviors of tr that exist in our evaluation
     grep-test            # Tests some interesting grep invocations
     ann-agg              # Tests custom aggregators in annotations
+    quoted_cmd           # Tests quoted and mixed-quote command names
     # # # # micro_1000           # Not being run anymore, as it is very slow. Tests whether the compiler is fast enough. It is a huge pipeline without any computation.
 )
 bash_skip=(

--- a/src/pash/compiler/annotations_utils/util_parsing.py
+++ b/src/pash/compiler/annotations_utils/util_parsing.py
@@ -20,7 +20,7 @@ from pash_annotations.parser.parser import (
 from pash_annotations.parser.util_parser import get_json_data
 
 
-from util import format_arg_chars, string_to_argument
+from util import format_arg_chars, remove_quotes_expanded_arg_chars, string_to_argument
 
 
 def merge_to_single_string_with_space(list_str):
@@ -65,7 +65,7 @@ def fix_parsing_newline(arg):
 def parse_arg_list_to_command_invocation(
     command, flags_options_operands
 ) -> CommandInvocationInitial:
-    cmd_name = format_arg_chars(command)
+    cmd_name = remove_quotes_expanded_arg_chars(command)
     json_data = get_json_data(cmd_name)
 
     set_of_all_flags: Set[str] = get_set_of_all_flags(json_data)

--- a/src/pash/compiler/util.py
+++ b/src/pash/compiler/util.py
@@ -11,8 +11,7 @@ import os
 import tempfile
 
 import config
-from shasta.ast_node import CArgChar
-
+from shasta.ast_node import CArgChar, EArgChar, QArgChar
 
 # === List utilities ===
 
@@ -28,6 +27,7 @@ def print_time_delta(prefix, start_time, end_time):
     """Log time delta between start and end time."""
     time_difference = (end_time - start_time) / timedelta(milliseconds=1)
     log("{} time:".format(prefix), time_difference, " ms")
+
 
 def log(*args, end="\n", level=2):
     """Wrapper for logging."""
@@ -118,6 +118,24 @@ class UnparsedScript:
 def format_arg_chars(arg_chars):
     chars = [arg_char.format() for arg_char in arg_chars]
     return "".join(chars)
+
+
+def remove_quotes_expanded_arg_chars(arg_chars):
+    """Format an expanded command name without its syntactic quotes.
+
+    Quoting affects how the shell expands a word, but it is not part of the
+    executable name. At this point command names must already be expanded, so
+    only literal, escaped, and quoted characters are valid.
+    """
+
+    def format_arg_char(arg_char):
+        if isinstance(arg_char, (CArgChar, EArgChar)):
+            return arg_char.format()
+        if isinstance(arg_char, QArgChar):
+            return "".join(format_arg_char(char) for char in arg_char.arg)
+        raise ValueError(f"Command name is not fully expanded: {arg_char!r}")
+
+    return "".join(format_arg_char(arg_char) for arg_char in arg_chars)
 
 
 def string_to_carg_char_list(string: str) -> "list[CArgChar]":


### PR DESCRIPTION
## Summary

- normalize fully expanded command-name ASTs before annotation lookup
- recursively remove syntactic `QArgChar` wrappers while preserving literal and escaped characters
- add an optimized regression covering double-quoted, single-quoted, and mixed-quote command names
- document the root cause, implementation, and validation for issue #741

## Root cause

PaSh used the general-purpose shell formatter when converting a command-name AST for annotation lookup. That formatter correctly reintroduced quote syntax, but annotations are keyed by the executable name (`cat`) rather than its shell spelling (`"cat"`). Quoted commands were consequently treated as unannotated and could not be parallelized.

The new command-name-specific formatter traverses expanded `CArgChar`, `EArgChar`, and nested `QArgChar` nodes without emitting syntactic quote wrappers. Other node types are rejected because annotation lookup requires a fully expanded command name. Operand formatting is unchanged.

## Validation

- seven positive compiler cases: unquoted, double-quoted, single-quoted, mixed, escaped, variable-expanded, and quoted operands
- three expected negative cases
- byte-for-byte Bash output comparison
- optimized Ubuntu 24.04 ARM64 runs at widths 2 and 8 with both Bash and Dash backends
- `--assert_all_regions_parallelizable` passed in all four optimized configurations
- AST normalization and quoted/unquoted annotation-parser equivalence checks
- Black, Bash syntax, Python byte-compilation, and `git diff --check`
- optimized intro suite: 3/3 passed

The complete repository suite was also attempted in Linux. The existing interface suite reported 23/43 passing, and the compiler harness stalled in the existing `comm-par-test` cases. These failures were outside the quoted-command path; the issue-specific matrix was rerun independently with timeouts and completed with zero failures.

Fixes #741
