### PR TITLE
Fix PASH_TOP path in local annotations

### DIFF
--- a/docs/local-annotations-library-documentation.md
+++ b/docs/local-annotations-library-documentation.md
@@ -29,13 +29,13 @@ Run:
 Before using PaSh, set the `PASH_TOP` environment variable to the directory where PaSh is stored:
 
 ```sh
-export PASH_TOP=/path/to/pash
+export PASH_TOP=/path/to/pash/src/pash
 ```
 
 To make this persistent across terminal sessions, add it to your shell configuration file:
 
 ```sh
-echo 'export PASH_TOP=/path/to/pash' >> ~/.bashrc
+echo 'export PASH_TOP=/path/to/pash/src/pash' >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -51,6 +51,8 @@ You can also provide the path to the PaSh repo directly if `PASH_TOP` is not set
 
 This will:
 - Clone the `annotations` repository as a **sibling** to `pash` (i.e., in the same parent directory), or in a specified path if provided.
+
+## **🔹 Step 3: Set PASH_TOP
 
 ## **🔹 Step 4: Run PaSh**
 Once everything is set up, test PaSh with:


### PR DESCRIPTION
The docs told users to set PASH_TOP to the pash repo root, but every script in the codebase (setup-pash.sh, ci.sh, the Dockerfiles) expects PASH_TOP to point to src/pash instead. Following the doc literally breaks setup-annotations.sh, since it computes the wrong repo root and tries to clone annotations to the wrong place. This fixes the doc to match the rest of the codebase, and adds a missing step number. 

Verified before/after:
- PASH_TOP=<repo root>            -> broken (wrong/failing clone location)
- PASH_TOP=<repo root>/src/pash   -> works, clones annotations correctly next to the repo

This fixes the doc to match the rest of the codebase, and adds a missing step number (jumped from Step 2 to Step 4). Ref #730 